### PR TITLE
Better playlist management (again)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.junkfood.seal">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.junkfood.seal">
 
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadPage.kt
@@ -45,6 +45,9 @@ import com.junkfood.seal.BaseApplication.Companion.context
 import com.junkfood.seal.R
 import com.junkfood.seal.ui.common.Route
 import com.junkfood.seal.util.PreferenceUtil
+import com.junkfood.seal.util.PreferenceUtil.CONFIGURE
+import com.junkfood.seal.util.PreferenceUtil.DEBUG
+import com.junkfood.seal.util.PreferenceUtil.PLAYLIST
 import com.junkfood.seal.util.PreferenceUtil.WELCOME_DIALOG
 import com.junkfood.seal.util.TextUtil
 
@@ -161,13 +164,19 @@ fun DownloadPage(
                         }
                         Column(Modifier.padding(24.dp)) {
                             AnimatedVisibility(visible = showVideoCard) {
-                                VideoCard(
-                                    videoTitle,
-                                    videoAuthor,
-                                    videoThumbnailUrl,
-                                    progress = progress,
-                                    onClick = { downloadViewModel.openVideoFile() },
-                                )
+	                            VideoCard(
+	                                videoTitle,
+	                                videoAuthor,
+	                                videoThumbnailUrl,
+	                                progress = progress,
+	                                playlistIndex = playlistIndex,
+	                                playlistCount = playlistCount,
+	                                onClick = { downloadViewModel.openVideoFile() },
+	                                stopNext = stopNext,
+	                                onCheckedChange = {
+	                                    downloadViewModel.stopNext(it)
+	                                },
+	                            )
                             }
 
                             InputUrl(
@@ -315,7 +324,11 @@ fun VideoCard(
     author: String = "author",
     thumbnailUrl: Any,
     onClick: () -> Unit,
-    progress: Float = 0f, modifier: Modifier = Modifier
+    stopNext: Boolean = false,
+    progress: Float = 0f, modifier: Modifier = Modifier,
+    onCheckedChange: ((Boolean) -> Unit)? = null,
+    playlistCount: Int = 1,
+    playlistIndex: Int = 1
 ) {
     ElevatedCard(
         modifier = modifier
@@ -370,6 +383,30 @@ fun VideoCard(
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f), maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
+            AnimatedVisibility(visible = PreferenceUtil.getValue(
+                PLAYLIST
+            ) && playlistIndex + 1 < playlistCount) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+
+                    Text(
+                        modifier = Modifier.padding(top = 3.dp),
+                        text = context.getString(R.string.stop_next) + " [" + (playlistIndex + 1) + "/" + playlistCount + "]",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                        overflow = TextOverflow.Ellipsis)
+                    Switch(
+                        checked = stopNext,
+                        onCheckedChange = onCheckedChange
+                    )
+                }
+            }
+
         }
         val progressAnimationValue by animateFloatAsState(
             targetValue = progress / 100f,

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
@@ -123,8 +123,11 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                     try {
                         videoInfo = DownloadUtil.fetchVideoInfo(viewState.value.url, i+1)
                     } catch (e: Exception) {
-                    	manageDownloadError(e)
-                        continue
+                        manageDownloadError(e)
+                        if (value.stopNext)
+                            break
+                        else
+                            continue
                     }
 /*                val palette = extractColorsFromImage(
                     TextUtil.urlHttpToHttps(
@@ -171,7 +174,10 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                             text = context.getString(R.string.download_error_msg),
                             intent = null
                         )
-                        continue
+                        if (value.stopNext)
+                            break
+                        else
+                            continue
                     }
                 val intent = FileUtil.createIntentForOpenFile(downloadResultTemp)
                 NotificationUtil.finishNotification(

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
@@ -123,6 +123,7 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                     try {
                         videoInfo = DownloadUtil.fetchVideoInfo(viewState.value.url, i+1)
                     } catch (e: Exception) {
+                    	manageDownloadError(e)
                         continue
                     }
 /*                val palette = extractColorsFromImage(
@@ -170,7 +171,7 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                             text = context.getString(R.string.download_error_msg),
                             intent = null
                         )
-                        return@launch
+                        continue
                     }
                 val intent = FileUtil.createIntentForOpenFile(downloadResultTemp)
                 NotificationUtil.finishNotification(

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
@@ -54,7 +54,10 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
             ModalBottomSheetValue.Hidden,
             isSkipHalfExpanded = true
         ),
-        val palette: Palette? = null
+        val palette: Palette? = null,
+        val stopNext:Boolean = false,
+        val playlistCount: Int = 0,
+        val playlistIndex: Int = 0
     )
 
     fun updateUrl(url: String) = _viewState.update { it.copy(url = url) }
@@ -72,6 +75,13 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
     }
 
     private var downloadResultTemp: DownloadUtil.Result = DownloadUtil.Result.failure()
+
+    fun CoroutineScope.manageDownloadError(e: Exception) = launch {
+        e.printStackTrace()
+        if (PreferenceUtil.getValue(PreferenceUtil.DEBUG))
+            showErrorReport(e.message ?: context.getString(R.string.unknown_error))
+        else showErrorMessage(context.getString(R.string.fetch_info_error_msg))
+    }
 
     fun startDownloadVideo() {
         switchDownloadMode(PreferenceUtil.getValue(PreferenceUtil.CUSTOM_COMMAND))
@@ -98,66 +108,70 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                     showErrorMessage(context.getString(R.string.url_empty))
                     return@launch
                 }
-                update { it.copy(isDownloadError = false) }
-                val videoInfo: VideoInfo
+                update { it.copy(isDownloadError = false, stopNext = false) }
+                var videoInfo: VideoInfo
+                var plCount: Int = 1
                 try {
-                    videoInfo = DownloadUtil.fetchVideoInfo(viewState.value.url)
+                    plCount = DownloadUtil.fetchPlaylistInfo(viewState.value.url)
                 } catch (e: Exception) {
-                    e.printStackTrace()
-                    if (PreferenceUtil.getValue(PreferenceUtil.DEBUG))
-                        showErrorReport(e.message ?: context.getString(R.string.unknown_error))
-                    else showErrorMessage(context.getString(R.string.fetch_info_error_msg))
+                    manageDownloadError(e)
                     return@launch
                 }
+                update { it.copy(playlistCount = plCount) }
+                var notificationID = value.url.hashCode()
+                for (i in 0 until plCount) {       // i in 1 until 10, excluding 10
+                    try {
+                        videoInfo = DownloadUtil.fetchVideoInfo(viewState.value.url, i+1)
+                    } catch (e: Exception) {
+                        continue
+                    }
 /*                val palette = extractColorsFromImage(
                     TextUtil.urlHttpToHttps(
                         videoInfo.thumbnail ?: ""
                     )
                 )*/
-                update {
-                    it.copy(
-                        progress = 0f,
-                        showVideoCard = true,
-                        videoTitle = videoInfo.title,
-                        videoAuthor = videoInfo.uploader ?: "null",
-                        videoThumbnailUrl = TextUtil.urlHttpToHttps(videoInfo.thumbnail ?: ""),
+                    update {
+                        it.copy(
+                            progress = 0f,
+                            playlistIndex = i,
+                            showVideoCard = true,
+                            videoTitle = videoInfo.title,
+                            videoAuthor = videoInfo.uploader ?: "null",
+                            videoThumbnailUrl = TextUtil.urlHttpToHttps(videoInfo.thumbnail ?: "")
 //                        palette = palette
-                    )
-                }
-//                PreferenceUtil.modifyThemeColor(palette.getVibrantColor(0xffffff))
-                val notificationID = value.url.hashCode()
-                try {
-                    NotificationUtil.makeNotification(
-                        notificationID,
-                        title = context.getString(R.string.download_notification_template)
-                            .format(videoInfo.title), text = ""
-                    )
-                    TextUtil.makeToastSuspend(
-                        context.getString(R.string.download_start_msg).format(videoInfo.title)
-                    )
-                    downloadResultTemp = DownloadUtil.downloadVideo(value.url, videoInfo)
-                    { progress, _, line ->
-                        _viewState.update { it.copy(progress = progress, progressText = line) }
-                        NotificationUtil.updateNotification(
-                            notificationID,
-                            progress = progress.toInt(),
-                            text = line
                         )
-
                     }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    if (PreferenceUtil.getValue(PreferenceUtil.DEBUG))
-                        showErrorReport(e.message ?: context.getString(R.string.unknown_error))
-                    else showErrorMessage(context.getString(R.string.download_error_msg))
-                    NotificationUtil.finishNotification(
-                        notificationID,
-                        title = videoInfo.title,
-                        text = context.getString(R.string.download_error_msg),
-                        intent = null
-                    )
-                    return@launch
-                }
+//                PreferenceUtil.modifyThemeColor(palette.getVibrantColor(0xffffff))
+                    notificationID = (value.url + (if (videoInfo.id != null) videoInfo.id else i)).hashCode()
+                    val appendS = " [" + (i+1) + "/" + plCount + "]"
+                    try {
+                        NotificationUtil.makeNotification(
+                            notificationID,
+                            title = context.getString(R.string.download_notification_template)
+                                .format(videoInfo.title) + appendS, text = ""
+                        )
+                        TextUtil.makeToastSuspend(
+                            context.getString(R.string.download_start_msg).format(videoInfo.title) + appendS
+                        )
+                        downloadResultTemp = DownloadUtil.downloadVideo(value.url, videoInfo) { progress, _, line ->
+                            _viewState.update { it.copy(progress = progress, progressText = line) }
+                            NotificationUtil.updateNotification(
+                                notificationID,
+                                progress = progress.toInt(),
+                                text = line
+                            )
+                        }
+
+                    } catch (e: Exception) {
+                        manageDownloadError(e)
+                        NotificationUtil.finishNotification(
+                            notificationID,
+                            title = videoInfo.title,
+                            text = context.getString(R.string.download_error_msg),
+                            intent = null
+                        )
+                        return@launch
+                    }
                 val intent = FileUtil.createIntentForOpenFile(downloadResultTemp)
                 NotificationUtil.finishNotification(
                     notificationID,
@@ -169,6 +183,10 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                         FileUtil.createIntentForOpenFile(downloadResultTemp), FLAG_IMMUTABLE
                     ) else null
                 )
+                    if (value.stopNext)
+                        break
+                }
+
                 finishProcessing()
                 /*                if (PreferenceUtil.getValue(PreferenceUtil.OPEN_IMMEDIATELY))
                                     openFile(downloadResultTemp)*/
@@ -305,6 +323,14 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
     fun openVideoFile() {
         if (_viewState.value.progress == 100f)
             openFile(downloadResultTemp)
+    }
+
+    fun stopNext(v: Boolean) {
+        _viewState.update {
+            it.copy(
+                stopNext = v
+            )
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/appearance/AppearancePreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/appearance/AppearancePreferences.kt
@@ -103,8 +103,7 @@ fun AppearancePreferences(
                 VideoCard(
                     modifier = Modifier.padding(18.dp),
                     thumbnailUrl = R.drawable.sample,
-                    onClick = {}, title = "Video title sample text", author = "Video creator sample text", progress = 100f,
-                    progressText = "75.9% of 173.97MiB at    8.52MiB/s ETA 00:04"
+                    onClick = {}, title = "Video title sample text", author = "Video creator sample text", progress = 100f
                 )
                 Column {
                     Row(

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/appearance/AppearancePreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/appearance/AppearancePreferences.kt
@@ -103,10 +103,8 @@ fun AppearancePreferences(
                 VideoCard(
                     modifier = Modifier.padding(18.dp),
                     thumbnailUrl = R.drawable.sample,
-                    onClick = {},
-                    title = "Video title sample text",
-                    author = "Video creator sample text",
-                    progress = 100f
+                    onClick = {}, title = "Video title sample text", author = "Video creator sample text", progress = 100f,
+                    progressText = "75.9% of 173.97MiB at    8.52MiB/s ETA 00:04"
                 )
                 Column {
                     Row(

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -53,7 +53,7 @@ object DownloadUtil {
             val resp: YoutubeDLResponse = YoutubeDL.getInstance().execute(request, null)
             val jsonObj = JSONObject(resp.out)
             val tp : String = jsonObj.getString("_type")
-            if (tp != null && tp == "playlist") {
+            if (tp == "playlist") {
                 playlistCount = jsonObj.getInt("playlist_count")
             }
         }
@@ -85,7 +85,7 @@ object DownloadUtil {
         val createThumbnail: Boolean = PreferenceUtil.getValue(PreferenceUtil.THUMBNAIL)
         val downloadPlaylist: Boolean = PreferenceUtil.getValue(PreferenceUtil.PLAYLIST)
         val concurrentFragments: Float = PreferenceUtil.getConcurrentFragments()
-        val realUrl = videoInfo?.webpageUrl?:(videoInfo?.url?:url)
+        val realUrl = videoInfo.webpageUrl?:(videoInfo.url?:url)
         val request = YoutubeDLRequest(realUrl)
         val id = if (extractAudio) "${url.hashCode()}audio" else realUrl.hashCode().toString()
         val pathBuilder = StringBuilder("$downloadDir/")

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -150,7 +150,7 @@ object DownloadUtil {
                     DownloadedVideoInfo(
                         0,
                         videoInfo.title,
-                        if (url != realUrl) "playlist" else if (videoInfo.uploader == null) "null" else videoInfo.uploader,
+                        if (videoInfo.uploader == null) "null" else videoInfo.uploader,
                         realUrl,
                         TextUtil.urlHttpToHttps(videoInfo.thumbnail ?: ""),
                         path,

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -85,7 +85,7 @@ object DownloadUtil {
         val createThumbnail: Boolean = PreferenceUtil.getValue(PreferenceUtil.THUMBNAIL)
         val downloadPlaylist: Boolean = PreferenceUtil.getValue(PreferenceUtil.PLAYLIST)
         val concurrentFragments: Float = PreferenceUtil.getConcurrentFragments()
-        val realUrl = videoInfo?.url?:(videoInfo.webpageUrl?:url)
+        val realUrl = videoInfo?.webpageUrl?:(videoInfo?.url:url)
         val request = YoutubeDLRequest(realUrl)
         val id = if (extractAudio) "${url.hashCode()}audio" else realUrl.hashCode().toString()
         val pathBuilder = StringBuilder("$downloadDir/")

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -85,7 +85,7 @@ object DownloadUtil {
         val createThumbnail: Boolean = PreferenceUtil.getValue(PreferenceUtil.THUMBNAIL)
         val downloadPlaylist: Boolean = PreferenceUtil.getValue(PreferenceUtil.PLAYLIST)
         val concurrentFragments: Float = PreferenceUtil.getConcurrentFragments()
-        val realUrl = videoInfo?.webpageUrl?:(videoInfo?.url:url)
+        val realUrl = videoInfo?.webpageUrl?:(videoInfo?.url?:url)
         val request = YoutubeDLRequest(realUrl)
         val id = if (extractAudio) "${url.hashCode()}audio" else realUrl.hashCode().toString()
         val pathBuilder = StringBuilder("$downloadDir/")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,4 +137,6 @@
     <string name="download_notification_desc">"Notify download progress and finish messages "</string>
     <string name="color_theming">Color theming</string>
     <string name="color_theming_desc">Choose color which apply to app theme</string>
+    <string name="fetching_playlist_info">Fetching playlist info</string>
+    <string name="stop_next">Stop after this video</string>
 </resources>


### PR DESCRIPTION
Hi,
I made again some changes in playlist management. Using the version in the current main branch, playlist download always shows the title and thumbnail of the first video of the playlist and is not stoppable. With the modifications of this PR, the thumbnail and the title of the current video download are showed and the user can stop the download at the end of each video. I added again the additional info text box under the thumbnail but it will be shown only when the debug preference is checked.