### PR TITLE
Service download

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="JDK" />
+        <option name="gradleJvm" value="Android Studio java home" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,6 +10,7 @@
         <entry key="app/src/main/java/com/junkfood/seal/ui/page/download/DownloadPage.kt" value="0.375" />
         <entry key="app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionDialog.kt" value="0.27954545454545454" />
         <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_baseline_close_24.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/ic_dashboard_black_24dp.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/ic_home_black_24dp.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/ic_launcher_background.xml" value="0.1" />
@@ -31,7 +32,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-parcelize")
 }
 apply(plugin = "dagger.hilt.android.plugin")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:name="android.permission.POST_NOTIFICATIONS"
         tools:targetApi="tiramisu" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name=".BaseApplication"
@@ -20,6 +21,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Seal">
+        <service
+            android:name=".service.VideoDownloadService"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.junkfood.service.action.MESSENGER"/>
+            </intent-filter>
+        </service>
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation"

--- a/app/src/main/java/com/junkfood/seal/BaseApplication.kt
+++ b/app/src/main/java/com/junkfood/seal/BaseApplication.kt
@@ -2,48 +2,36 @@ package com.junkfood.seal
 
 import android.annotation.SuppressLint
 import android.app.Application
-import android.content.ClipboardManager
-import android.content.Context
-import android.os.Build
-import android.os.Environment
+import android.content.*
+import android.os.*
+import android.util.Log
 import com.google.android.material.color.DynamicColors
-import com.junkfood.seal.util.DownloadUtil
+import com.junkfood.seal.service.Constants
+import com.junkfood.seal.service.VideoDownloadService
 import com.junkfood.seal.util.NotificationUtil
 import com.junkfood.seal.util.PreferenceUtil
 import com.junkfood.seal.util.PreferenceUtil.AUDIO_DIRECTORY
 import com.junkfood.seal.util.PreferenceUtil.VIDEO_DIRECTORY
 import com.junkfood.seal.util.PreferenceUtil.YT_DLP
 import com.tencent.mmkv.MMKV
-import com.yausername.ffmpeg.FFmpeg
-import com.yausername.youtubedl_android.YoutubeDL
-import com.yausername.youtubedl_android.YoutubeDLException
 import dagger.hilt.android.HiltAndroidApp
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import java.io.File
+
 
 @HiltAndroidApp
 class BaseApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         MMKV.initialize(this)
+        context = applicationContext
         applicationScope = CoroutineScope(SupervisorJob())
         DynamicColors.applyToActivitiesIfAvailable(this)
         clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        applicationScope.launch {
-            withContext(Dispatchers.IO) {
-                try {
-                    YoutubeDL.getInstance().init(this@BaseApplication)
-                    FFmpeg.getInstance().init(this@BaseApplication)
-                    if (PreferenceUtil.getString(YT_DLP).isNullOrEmpty()) {
-                        DownloadUtil.updateYtDlp()
-                    }
-                } catch (e: YoutubeDLException) {
-                    e.printStackTrace()
-                }
-            }
-        }
-        ytdlpVersion =
-            YoutubeDL.getInstance().version(this) ?: resources.getString(R.string.ytdlp_update)
 
 
         with(PreferenceUtil.getString(VIDEO_DIRECTORY)) {
@@ -59,19 +47,56 @@ class BaseApplication : Application() {
             audioDownloadDir = if (isNullOrEmpty()) File(videoDownloadDir, "Audio").absolutePath
             else this
         }
-        context = applicationContext
+        bindServiceInvoked()
         if (Build.VERSION.SDK_INT >= 26)
             NotificationUtil.createNotificationChannel()
     }
 
+    //Receive messages from the server
+    class ClientHandler : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(msg: Message) {
+            when (msg.what) {
+                Constants.What.WHAT_YTDLP_VERSION.ordinal -> {
+                    Log.i(TAG, "ver ok")
+                    val b = msg.peekData()
+                    if (msg.arg1 != Constants.What.WHAT_ERROR.ordinal && b != null) {
+                        val s = b.getString(Constants.What.WHAT_YTDLP_VERSION.name)!!
+                        PreferenceUtil.updateString(YT_DLP, s)
+                        ytdlpVersionM.update { s }
+                    }
+                }
+            }
+        }
+    }
 
     companion object {
         private const val TAG = "BaseApplication"
+        private val mMessenger = Messenger(ClientHandler())
+        var mService: Messenger? = null
+        var messageToSend: Message? = null
+        private val ytdlpVersionM = MutableStateFlow("")
+        val ytdlpVersion = ytdlpVersionM.asStateFlow()
         lateinit var clipboard: ClipboardManager
         lateinit var videoDownloadDir: String
         lateinit var audioDownloadDir: String
-        var ytdlpVersion = ""
         lateinit var applicationScope: CoroutineScope
+        private var isBinding = false
+        private val intentToService by lazy {
+            Intent(context, VideoDownloadService::class.java)
+        }
+        fun updateytDlp(force: Boolean = false) {
+            val s = PreferenceUtil.getString(YT_DLP)
+            if (s.isNullOrEmpty() || force) {
+                val b = Bundle()
+                b.putString(Constants.What.WHAT_YTDLP_VERSION.name, "")
+                val m = Message.obtain(null, Constants.What.WHAT_YTDLP_VERSION.ordinal)
+                m.replyTo = mMessenger
+                m.data = b
+                sendMessage(m)
+            }
+            else
+                ytdlpVersionM.update { s }
+        }
         fun updateDownloadDir(path: String, isAudio: Boolean = false) {
             if (isAudio) {
                 audioDownloadDir = path
@@ -79,6 +104,59 @@ class BaseApplication : Application() {
             } else {
                 videoDownloadDir = path
                 PreferenceUtil.updateString(VIDEO_DIRECTORY, path)
+            }
+        }
+
+        fun sendMessage(m: Message) {
+            if (mService == null) {
+                messageToSend = m
+                bindServiceInvoked()
+            }
+            else
+                mService!!.send(m)
+        }
+
+        //Receive service connection and disconnection messages
+        var serviceConnection: ServiceConnection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName, service: IBinder) {
+                Log.i(TAG, "service connected")
+                isBinding = false
+                mService = Messenger(service)
+
+                //Since the server does not have the client's messenger after binding, send the client's messenger to the server after binding
+                if (mService != null) {
+                    try {
+                        Log.d(TAG, "send messenger")
+                        updateytDlp()
+                        if (messageToSend != null) {
+                            sendMessage(messageToSend!!)
+                            messageToSend = null
+                        }
+                    } catch (e: RemoteException) {
+                        e.printStackTrace()
+                    }
+                }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName) {
+                Log.i("client", "service disconnected")
+                mService = null
+                isBinding = false
+            }
+
+            override fun onBindingDied(name: ComponentName?) {
+                mService = null
+                isBinding = false
+            }
+        }
+
+        private fun bindServiceInvoked() {
+            if (!isBinding) {
+                val intent = Intent()
+                intent.action = "com.junkfood.service.action.MESSENGER"
+                intent.setPackage("com.junkfood.service")
+                isBinding = true
+                context.bindService(intentToService, serviceConnection, BIND_AUTO_CREATE)
             }
         }
 

--- a/app/src/main/java/com/junkfood/seal/BaseApplication.kt
+++ b/app/src/main/java/com/junkfood/seal/BaseApplication.kt
@@ -152,9 +152,6 @@ class BaseApplication : Application() {
 
         private fun bindServiceInvoked() {
             if (!isBinding) {
-                val intent = Intent()
-                intent.action = "com.junkfood.service.action.MESSENGER"
-                intent.setPackage("com.junkfood.service")
                 isBinding = true
                 context.bindService(intentToService, serviceConnection, BIND_AUTO_CREATE)
             }

--- a/app/src/main/java/com/junkfood/seal/BaseApplication.kt
+++ b/app/src/main/java/com/junkfood/seal/BaseApplication.kt
@@ -79,7 +79,7 @@ class BaseApplication : Application() {
         }
 
         //Receive service connection and disconnection messages
-        var serviceConnection: ServiceConnection = object : ServiceConnection {
+        private val serviceConnection: ServiceConnection = object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName, service: IBinder) {
                 Log.i(TAG, "service connected")
                 isBinding = false

--- a/app/src/main/java/com/junkfood/seal/service/Constants.kt
+++ b/app/src/main/java/com/junkfood/seal/service/Constants.kt
@@ -1,0 +1,19 @@
+package com.junkfood.seal.service
+
+object Constants {
+    const val ACTION_NOTIFICATION_NAME = "ACTION_NOTIFICATION_NAME"
+    const val ACTION_START = "START"
+    const val ACTION_STOP = "STOP"
+    const val ACTION_NOTIFICATION_KEY = "ACTION_NOTIFICATION_KEY"
+    const val NOTIFICATION_ID = 123
+    const val CHANNEL_ID = "SealVideoService"
+    const val NO_ERROR = -1
+    enum class What {
+        WHAT_YTDLP_VERSION,
+        WHAT_APPEND_TASK,
+        WHAT_TASK_HALT,
+        WHAT_APPEND_TASK_ASK,
+        WHAT_TASK_PROGRESS,
+        WHAT_ERROR,
+    }
+}

--- a/app/src/main/java/com/junkfood/seal/service/VideoDownloadService.kt
+++ b/app/src/main/java/com/junkfood/seal/service/VideoDownloadService.kt
@@ -287,7 +287,7 @@ class VideoDownloadService : Service() {
         serviceScope.launch(Dispatchers.IO) {
             if (task.settings.isCustom())
                 downloadWithCustomCommands()
-            else if (task.settings.downloadPlaylist && task.endItem - task.startItem > 0)
+            else if (task.settings.downloadPlaylist && task.endItem - task.startItem >= 0 && task.endItem > 0 && task.startItem > 0)
                 downloadVideoInPlaylistByIndexRange()
             else
                 downloadVideo()

--- a/app/src/main/java/com/junkfood/seal/service/VideoDownloadService.kt
+++ b/app/src/main/java/com/junkfood/seal/service/VideoDownloadService.kt
@@ -1,0 +1,573 @@
+package com.junkfood.seal.service
+
+import android.annotation.SuppressLint
+import android.app.*
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.graphics.drawable.Icon
+import android.os.*
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.junkfood.seal.MainActivity
+import com.junkfood.seal.R
+import com.junkfood.seal.service.Constants.What.*
+import com.junkfood.seal.util.*
+import com.yausername.ffmpeg.FFmpeg
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLException
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import com.yausername.youtubedl_android.mapper.VideoInfo
+import kotlinx.coroutines.*
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.regex.Pattern
+
+
+class VideoDownloadService : Service() {
+    private lateinit var notificationBuilder: Notification.Builder
+    class MutableLiveState : MutableLiveData<ServiceState>(ServiceState()) {
+        var oldTask: DownloadTask? = null
+        override fun setValue(v: ServiceState?) {
+            oldTask = value!!.task
+            super.setValue(v)
+        }
+        override fun postValue(v: ServiceState?) {
+            oldTask = value!!.task
+            super.postValue(v)
+        }
+    }
+    private val downloadClient = MutableLiveData<Messenger>(null)
+    private val mTaskList = ConcurrentLinkedQueue<DownloadTask>()
+
+    private val currentState = MutableLiveState()
+
+    private val currentTaskObserver =
+        Observer<ServiceState> { s ->
+            val b = Bundle()
+            b.putBoolean(WHAT_TASK_PROGRESS.name + "0", s.task != currentState.oldTask)
+            b.putParcelable(WHAT_TASK_PROGRESS.name, s)
+            sendMessage(WHAT_TASK_PROGRESS.ordinal, b)
+        }
+
+    private val mClientObserver =
+        Observer<Messenger> { cli ->
+            if (cli == null) {
+                currentState.removeObserver(currentTaskObserver)
+            }
+            else {
+                currentState.observeForever(currentTaskObserver)
+            }
+        }
+
+    private val taskChangeObserver =
+        Observer<ServiceState> { s->
+            if (s.task != currentState.oldTask && s.task != null) {
+                startDownloadVideo(s.task)
+            }
+        }
+
+    private val notificationReceiver: BroadcastReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                when (intent.extras?.getString(Constants.ACTION_NOTIFICATION_NAME)) {
+                    Constants.ACTION_STOP -> {
+                        Log.i(TAG, "Stop Notification Action has been clicked")
+                        stopForegroundService()
+                    }
+                }
+            }
+        }
+
+    private fun manageDownloadError(
+        e: Exception,
+        isFetchingInfo: Boolean = true,
+        notificationId: Int? = null
+    ) =
+        serviceScope.launch {
+            e.printStackTrace()
+            val b = Bundle()
+            b.putParcelable(WHAT_TASK_PROGRESS.name, currentState.value)
+            sendError(WHAT_TASK_PROGRESS.ordinal,
+                if (isFetchingInfo) R.string.download_error_msg else R.string.fetch_info_error_msg,
+                message=e.message)
+            notificationId?.let {
+                NotificationUtil.finishNotification(
+                    notificationId, text = context.getString(R.string.download_error_msg),
+                )
+            }
+        }
+
+    private fun parsePlaylistInfo(task: DownloadTask, to: Messenger?) {
+        serviceScope.launch(Dispatchers.IO) {
+            try {
+                val playlistSize = DownloadUtilService.getPlaylistSize(task.url)
+                val b = Bundle()
+                if (playlistSize > 1) {
+                    b.putParcelable(WHAT_APPEND_TASK_ASK.name, task)
+                    sendMessage(
+                        WHAT_APPEND_TASK_ASK.ordinal,
+                        data = b,
+                        arg1 = playlistSize,
+                        to = to
+                    )
+                }
+                else if (playlistSize == 1){
+                    mTaskList.add(task)
+                    b.putParcelable(WHAT_APPEND_TASK.name, task)
+                    sendMessage(WHAT_APPEND_TASK.ordinal, b, to)
+                    taskProcess()
+                }
+                else
+                    throw Exception("Empty Playlist")
+            } catch (e: Exception) {
+                sendError(WHAT_APPEND_TASK_ASK.ordinal, R.string.fetch_info_error_msg, to = to, message = e.message)
+            }
+        }
+    }
+
+    private suspend fun downloadVideo(index: Int = 1) {
+        with(currentState) {
+            val url = value!!.task!!.url
+            lateinit var videoInfo: VideoInfo
+            try {
+                videoInfo = DownloadUtilService.fetchVideoInfo(url, index)
+            } catch (e: Exception) {
+                manageDownloadError(e)
+                return
+            }
+            Log.d(TAG, "downloadVideo: $index" + videoInfo.title)
+            postValue(value!!.copy(
+                state = value!!.state.copy(
+                    progress = 0f,
+                    showVideoCard = true,
+                    videoTitle = videoInfo.title,
+                    videoAuthor = videoInfo.uploader ?: "null",
+                    videoThumbnailUrl = TextUtil.urlHttpToHttps(videoInfo.thumbnail ?: "")
+                )
+            ))
+            val notificationId = (url + index).hashCode()
+            var intent: Intent? = null
+            var downloadResultTemp: DownloadUtilService.Result = DownloadUtilService.Result.failure()
+            try {
+                NotificationUtil.makeNotification(notificationId, videoInfo.title)
+                downloadResultTemp =
+                    DownloadUtilService.downloadVideo(videoInfo, value!!.task!!) { progress, _, line ->
+                        postValue(value!!.copy(
+                            state = value!!.state.copy(
+                                progress = progress,
+                                progressText = line
+                            )
+                        ))
+                        NotificationUtil.updateNotification(
+                            notificationId,
+                            progress = progress.toInt(),
+                            text = line
+                        )
+                    }
+                intent = FileUtil.createIntentForOpenFileService(downloadResultTemp)
+            } catch (e: Exception) {
+                manageDownloadError(e, false, notificationId)
+            }
+
+            NotificationUtil.finishNotification(
+                notificationId,
+                title = videoInfo.title,
+                text = context.getString(R.string.download_finish_notification),
+                intent = if (intent != null) PendingIntent.getActivity(
+                    context,
+                    0,
+                    FileUtil.createIntentForOpenFileService(downloadResultTemp),
+                    PendingIntent.FLAG_IMMUTABLE
+                ) else null
+            )
+            if (intent != null) {
+                postValue(value!!.copy(
+                    state = value!!.state.copy(
+                        fileNames = downloadResultTemp.filePath
+                    )
+                ))
+            }
+        }
+    }
+
+    private fun downloadWithCustomCommands() {
+        with(currentState) {
+            val task = value!!.task!!
+            val url = task.url
+            val request = YoutubeDLRequest(url)
+            request.addOption("-P", "${task.settings.videoDownloadDir}/")
+            val m =
+                Pattern.compile("\"([^\"]*)\"|(\\S+)")
+                    .matcher(task.settings.command!!)
+            while (m.find()) {
+                if (m.group(1) != null) {
+                    request.addOption(m.group(1))
+                } else {
+                    request.addOption(m.group(2))
+                }
+            }
+            postValue(value!!.copy(
+                state = value!!.state.copy(
+                    progress = 0f,
+                    showVideoCard = false,
+                )
+            ))
+            serviceScope.launch(Dispatchers.IO) {
+                try {
+                    if (url.isNotEmpty())
+                        with(DownloadUtilService.fetchVideoInfo(url)) {
+                            if (!title.isNullOrEmpty() and !thumbnail.isNullOrEmpty())
+                                postValue(value!!.copy( state = value!!.state.copy(
+                                     videoTitle = title,
+                                     videoThumbnailUrl = TextUtil.urlHttpToHttps(thumbnail),
+                                     videoAuthor = uploader ?: "null",
+                                     showVideoCard = true
+                                 )))
+                        }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+            val notificationId = url.hashCode()
+            NotificationUtil.makeNotification(
+                notificationId,
+                title = context.getString(R.string.execute_command_notification),
+                text = ""
+            )
+            serviceScope.launch(Dispatchers.IO) {
+                try {
+                    YoutubeDL.getInstance().execute(request) { progress, _, line ->
+                        postValue(value!!.copy( state = value!!.state.copy(
+                            progress = progress,
+                            progressText = line)
+                        ))
+                        NotificationUtil.updateNotification(
+                            notificationId,
+                            progress = progress.toInt(),
+                            text = line
+                        )
+                    }
+                    NotificationUtil.finishNotification(
+                        notificationId,
+                        title = context.getString(R.string.download_success_msg),
+                        text = null,
+                        intent = null
+                    )
+                } catch (e: Exception) {
+                    manageDownloadError(e, false, notificationId)
+                    return@launch
+                }
+            }
+        }
+    }
+
+    private suspend fun downloadVideoInPlaylistByIndexRange() {
+        with(currentState) {
+            val currentTask = value!!.task!!
+            val indexRange = IntRange(currentTask.startItem, currentTask.endItem)
+            var curIdx = 0
+            var itCnt = indexRange.last - indexRange.first + 1
+            postValue(
+                value!!.copy(
+                    state = value!!.state.copy(
+                        downloadItemCount = itCnt,
+                        currentIndex = curIdx
+                    )
+                )
+            )
+            for (index in indexRange) {
+                Log.d(TAG, "Downloading $index")
+                if (curIdx >= itCnt)
+                    break
+                val st = value!!.state.copy(
+                    currentIndex = index - indexRange.first + 1,
+                    downloadItemCount = itCnt,
+                )
+                postValue(
+                    value!!.copy(
+                        state = st
+                    )
+                )
+                downloadVideo(index)
+                curIdx = value!!.state.currentIndex
+                itCnt = value!!.state.downloadItemCount
+            }
+        }
+    }
+
+    private fun startDownloadVideo(task: DownloadTask) {
+        serviceScope.launch(Dispatchers.IO) {
+            if (task.settings.isCustom())
+                downloadWithCustomCommands()
+            else if (task.settings.downloadPlaylist && task.endItem - task.startItem > 0)
+                downloadVideoInPlaylistByIndexRange()
+            else
+                downloadVideo()
+            finishProcessing()
+        }
+    }
+
+    private fun finishProcessing() {
+        taskProcess(true)
+    }
+
+    private fun updateYtDlp(to: Messenger) {
+        serviceScope.launch(Dispatchers.IO) {
+            try {
+                YoutubeDL.getInstance().updateYoutubeDL(context)
+            } catch (e: Exception) {
+
+            }
+
+            YoutubeDL.getInstance().version(context)?.let {
+                ytdlpVersion = it
+            }
+            val b = Bundle()
+            b.putString(WHAT_YTDLP_VERSION.name, ytdlpVersion)
+            sendMessage(WHAT_YTDLP_VERSION.ordinal, b, to)
+        }
+    }
+
+    private val messageHandler = object : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(msg: Message) {
+            //Processing messages
+            when (msg.what) {
+                WHAT_YTDLP_VERSION.ordinal -> {
+                    Log.d(TAG, "receive messenger")
+                    val b = msg.peekData()
+                    val ver = b.getString(WHAT_YTDLP_VERSION.name)
+                    if (ver!!.isEmpty()) {
+                        updateYtDlp(msg.replyTo)
+                    }
+                    else {
+                        b.putString(WHAT_YTDLP_VERSION.name, ytdlpVersion)
+                        sendMessage(msg.what, b, msg.replyTo, download=false)
+                    }
+                }
+                WHAT_APPEND_TASK.ordinal -> {
+                    val b = msg.peekData()
+                    try {
+                        b.classLoader = DownloadTask::class.java.classLoader
+                        val task = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) b.getParcelable(WHAT_APPEND_TASK.name) else b.getParcelable(WHAT_APPEND_TASK.name, DownloadTask::class.java)
+                        if (task?.url!!.isNotEmpty()) {
+                            if (!task.settings.isCustom() && task.settings.downloadPlaylist && task.endItem == 0) {
+                                parsePlaylistInfo(task, msg.replyTo)
+                            }
+                            else {
+                                mTaskList.add(task)
+                                sendMessage(msg.what, b, msg.replyTo)
+                                taskProcess()
+                            }
+                        }
+                        else
+                            sendError(msg.what, R.string.url_empty, to =  msg.replyTo)
+                    }
+                    catch (e: Exception) {
+                        e.printStackTrace()
+                        sendError(msg.what, R.string.invalid_task_error, message=e.message, to =  msg.replyTo)
+                    }
+                }
+                WHAT_TASK_PROGRESS.ordinal -> {
+                    Log.d(TAG, "New download receiver detected")
+                    downloadClient.postValue(msg.replyTo)
+                }
+                WHAT_TASK_HALT.ordinal -> {
+                    val b = msg.peekData()
+                    try {
+                        b.classLoader = DownloadTask::class.java.classLoader
+                        val task = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) b.getParcelable(WHAT_TASK_HALT.name) else b.getParcelable(WHAT_TASK_HALT.name, DownloadTask::class.java)
+                        val st = currentState.value!!.state
+                        val ct = currentState.value!!.task!!
+                        if (task!!.url == ct.url && st.downloadItemCount > st.currentIndex) {
+                            currentState.postValue(
+                                currentState.value!!.copy(
+                                    state = currentState.value!!.state.copy(
+                                        downloadItemCount = st.currentIndex,
+                                    )
+                                )
+                            )
+                            b.putBoolean(WHAT_TASK_HALT.name + "0", true)
+                        }
+                        else {
+                            b.putBoolean(WHAT_TASK_HALT.name + "0", false)
+                        }
+                        sendMessage(msg.what, b, msg.replyTo)
+                    }
+                    catch (e: Exception) {
+                        e.printStackTrace()
+                        sendError(msg.what, R.string.invalid_task_error, message=e.message, to =  msg.replyTo)
+                    }
+                }
+                else -> {}
+            }
+        }
+    }
+    private val messenger: Messenger = Messenger(messageHandler)
+
+    fun taskProcess(force: Boolean = false) {
+        with(currentState) {
+            if (value!!.task == null || force) {
+                val task = mTaskList.poll()
+
+                postValue(
+                   value!!.copy(
+                        task = task,
+                        state = value!!.state.copy(
+                            progress = 100f,
+                            progressText = "",
+                            downloadItemCount = 0,
+                            currentIndex = 0
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        Log.i(TAG, "service bind")
+        return messenger.binder
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        Log.i(TAG, "service unbind")
+        downloadClient.postValue(null)
+        return super.onUnbind(intent)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.i(TAG, "Start Service ..............................")
+        context = this
+        downloadClient.observeForever(mClientObserver)
+        currentState.observeForever(taskChangeObserver)
+
+        startForegroundService()
+        serviceScope = CoroutineScope(SupervisorJob())
+        serviceScope.launch {
+            withContext(Dispatchers.IO) {
+                try {
+                    YoutubeDL.getInstance().init(this@VideoDownloadService)
+                    FFmpeg.getInstance().init(this@VideoDownloadService)
+                } catch (e: YoutubeDLException) {
+                    e.printStackTrace()
+                }
+            }
+        }
+        ytdlpVersion =
+            YoutubeDL.getInstance().version(this) ?: resources.getString(R.string.ytdlp_update)
+    }
+
+    fun sendError(what: Int, errorCode: Int, to: Messenger? = null, message: String? = null) {
+        var b: Bundle? = null
+        if (message != null) {
+            b = Bundle()
+            b.putString(WHAT_ERROR.name, message)
+        }
+        sendMessage(what, arg1 = -WHAT_ERROR.ordinal, data = b, arg2 = errorCode, to = to)
+    }
+
+    fun sendMessage(what: Int, data: Bundle? = null, to: Messenger? = null, arg1: Int = Constants.NO_ERROR, arg2: Int = Constants.NO_ERROR, download: Boolean = true) {
+        if ((null == downloadClient.value && to == null) || (to == null && !download)) {
+            Log.d(TAG, "client is null")
+            return
+        }
+        try {
+            val message: Message = Message.obtain(null, what)
+            message.arg1 = arg1
+            message.arg2 = arg2
+            message.data = data
+            var dest: Messenger? = to
+            if (to != null && download)
+                downloadClient.postValue(to)
+            else if (to == null)
+                dest = downloadClient.value!!
+            dest!!.send(message)
+        } catch (e: RemoteException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun startForegroundService() {
+
+        val notification: Notification = getNotification()
+
+        registerReceiver(notificationReceiver, IntentFilter(Constants.ACTION_NOTIFICATION_KEY))
+
+        // Notification ID cannot be 0.
+        startForeground(Constants.NOTIFICATION_ID, notification)
+    }
+
+    @SuppressLint("UnspecifiedImmutableFlag")
+    private fun getNotification(): Notification {
+
+        // Create an explicit intent for an Activity in your app
+        val intentMain = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntentMain = PendingIntent.getActivity(this, 0, intentMain, PendingIntent.FLAG_IMMUTABLE)
+
+        val intentStop = Intent(this, notificationReceiver.javaClass).apply {
+            action = Constants.ACTION_STOP
+        }
+        val pendingIntentStop = PendingIntent.getBroadcast(
+            this, 0, intentStop, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val chan = NotificationChannel(
+                Constants.CHANNEL_ID,
+                "VideoDownloadService Bys Seal",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val manager = (getSystemService(NOTIFICATION_SERVICE) as NotificationManager)!!
+            manager!!.createNotificationChannel(chan)
+            notificationBuilder = Notification.Builder(this, Constants.CHANNEL_ID)
+                .setContentTitle(getText(R.string.seal_service))
+                .setContentText(context.getString(R.string.seal_service_running))
+                .setSmallIcon(R.drawable.seal)
+                .setContentIntent(pendingIntentMain)
+                .setAutoCancel(true)
+                .setOnlyAlertOnce(true)
+                .setOngoing(true)
+                .setCategory(Notification.CATEGORY_PROGRESS)
+                .setAutoCancel(true)
+                .setStyle(Notification.DecoratedMediaCustomViewStyle())
+                //.setCustomContentView(RemoteViews(this.packageName, R.layout.layout_notification))
+                .addAction(
+                    Notification.Action.Builder(
+                        Icon.createWithResource(this, R.drawable.ic_baseline_close_24),
+                        getText(R.string.btn_stop),
+                        pendingIntentStop
+                    ).build()
+                )
+        }
+        return notificationBuilder.build()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i(TAG, "Stop Service ...............................")
+        unregisterReceiver(notificationReceiver)
+    }
+
+    private fun stopForegroundService() {
+        Log.d(TAG, "Stop foreground service.")
+
+        // Stop foreground service and remove the notification.
+        stopForeground(STOP_FOREGROUND_REMOVE)
+
+        // Stop the foreground service.
+        stopSelf()
+    }
+
+    companion object {
+        private const val TAG = "VideoDownloadService"
+        var ytdlpVersion = ""
+        lateinit var serviceScope: CoroutineScope
+        @SuppressLint("StaticFieldLeak")
+        lateinit var context: Context
+    }
+}

--- a/app/src/main/java/com/junkfood/seal/service/VideoDownloadService.kt
+++ b/app/src/main/java/com/junkfood/seal/service/VideoDownloadService.kt
@@ -301,7 +301,7 @@ class VideoDownloadService : Service() {
 
     private fun updateYtDlp(to: Messenger) {
         serviceScope.launch(Dispatchers.IO) {
-            var rv: YoutubeDL.UpdateStatus
+            val rv: YoutubeDL.UpdateStatus
             try {
                 rv = YoutubeDL.getInstance().updateYoutubeDL(context)
             } catch (e: Exception) {
@@ -470,8 +470,7 @@ class VideoDownloadService : Service() {
             var dest: Messenger? = to
             if (to != null)
                 downloadClient.postValue(to)
-            else if (to == null)
-                dest = downloadClient.value!!
+            else dest = downloadClient.value!!
             dest!!.send(message)
         } catch (e: RemoteException) {
             e.printStackTrace()
@@ -487,7 +486,7 @@ class VideoDownloadService : Service() {
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
-        if (Constants.ACTION_STOP.equals(intent.action)) {
+        if (Constants.ACTION_STOP == intent.action) {
             Log.d(TAG, "called to cancel service")
             stopForegroundService()
         }
@@ -503,7 +502,7 @@ class VideoDownloadService : Service() {
         }
         val pendingIntentMain = PendingIntent.getActivity(this, 0, intentMain, PendingIntent.FLAG_IMMUTABLE)
         val intentStop = Intent(this, VideoDownloadService::class.java)
-        intentStop.setAction(Constants.ACTION_STOP)
+        intentStop.action = Constants.ACTION_STOP
         val pendingIntentStop =
             PendingIntent.getService(this, 0, intentStop, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 

--- a/app/src/main/java/com/junkfood/seal/ui/page/HomeEntry.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/HomeEntry.kt
@@ -39,6 +39,7 @@ fun HomeEntry(
                     animatedComposable(Route.SETTINGS) { SettingsPage(navController) }
                     animatedComposable(Route.DOWNLOAD_PREFERENCES) {
                         DownloadPreferences(
+                            downloadViewModel,
                             onBackPressed = { onBackPressed() }
                         ) { navController.navigate(Route.DOWNLOAD_DIRECTORY) }
                     }

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadPage.kt
@@ -89,7 +89,7 @@ fun DownloadPage(
             }
             Scaffold(floatingActionButton = {
                 FABs(
-                    with(Modifier.systemBarsPadding()) { if (showVideoCard) this else this.imePadding() },
+                    with(Modifier.systemBarsPadding()) { if (state.showVideoCard) this else this.imePadding() },
                     downloadCallback = {
                         if (PreferenceUtil.getValue(PreferenceUtil.CONFIGURE, true))
                             downloadViewModel.showDrawer(scope)
@@ -131,20 +131,20 @@ fun DownloadPage(
                     TitleWithProgressIndicator(
                         isProcessing = isProcessing,
                         isDownloadingPlaylist = isDownloadingPlaylist,
-                        currentIndex = currentIndex,
-                        downloadItemCount = downloadItemCount,
+                        currentIndex = state.currentIndex,
+                        downloadItemCount = state.downloadItemCount,
                         onClick = {
                             downloadViewModel.stopDownloadPlaylistOnNextItem()
                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                         }
                     )
                     Column(Modifier.padding(24.dp)) {
-                        AnimatedVisibility(visible = showVideoCard) {
+                        AnimatedVisibility(visible = state.showVideoCard) {
                             VideoCard(
-                                Modifier, videoTitle,
-                                videoAuthor,
-                                videoThumbnailUrl,
-                                progress = progress,
+                                Modifier, state.videoTitle,
+                                state.videoAuthor,
+                                state.videoThumbnailUrl,
+                                progress = state.progress,
                                 onClick = { downloadViewModel.openVideoFile() },
                             )
                         }
@@ -152,14 +152,14 @@ fun DownloadPage(
                         InputUrl(
                             url = url,
                             hint = stringResource(R.string.video_url),
-                            progress = progress,
-                            showVideoCard = showVideoCard,
+                            progress = state.progress,
+                            showVideoCard = state.showVideoCard,
                             isInCustomMode = isInCustomCommandMode,
                             error = isDownloadError,
                         ) { url -> downloadViewModel.updateUrl(url) }
-                        AnimatedVisibility(visible = debugMode && progressText.isNotEmpty()) {
+                        AnimatedVisibility(visible = debugMode && state.progressText.isNotEmpty()) {
                             Text(
-                                text = progressText,
+                                text = state.progressText,
                                 maxLines = 3,
                                 overflow = TextOverflow.Ellipsis,
                                 style = MaterialTheme.typography.bodyMedium

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
@@ -1,8 +1,6 @@
 package com.junkfood.seal.ui.page.download
 
-import android.app.PendingIntent
-import android.app.PendingIntent.FLAG_IMMUTABLE
-import android.content.Intent
+import android.os.*
 import android.util.Log
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetState
@@ -12,50 +10,178 @@ import androidx.lifecycle.viewModelScope
 import com.junkfood.seal.BaseApplication
 import com.junkfood.seal.BaseApplication.Companion.context
 import com.junkfood.seal.R
+import com.junkfood.seal.service.Constants.What.*
 import com.junkfood.seal.util.*
 import com.junkfood.seal.util.FileUtil.openFile
-import com.yausername.youtubedl_android.YoutubeDL
-import com.yausername.youtubedl_android.YoutubeDLRequest
-import com.yausername.youtubedl_android.mapper.VideoInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.regex.Pattern
 import javax.inject.Inject
+
 
 @HiltViewModel
 @OptIn(ExperimentalMaterialApi::class)
 class DownloadViewModel @Inject constructor() : ViewModel() {
 
-    private val mutableStateFlow = MutableStateFlow(DownloadViewState())
+    private val mutableStateFlow = MutableStateFlow(DownloadViewState(
+        debugMode = PreferenceUtil.getValue(
+            PreferenceUtil.DEBUG)))
     val stateFlow = mutableStateFlow.asStateFlow()
 
     data class DownloadViewState(
-        val showVideoCard: Boolean = false,
-        val showPlaylistSelectionDialog: Boolean = false,
-        val progress: Float = 0f,
         val url: String = "",
-        val videoTitle: String = "",
-        val videoThumbnailUrl: String = "",
-        val videoAuthor: String = "",
+        val urlTask: String = "",
         val isDownloadError: Boolean = false,
-        val errorMessage: String = "",
-        val progressText: String = "",
         val isInCustomCommandMode: Boolean = false,
         val isProcessing: Boolean = false,
         val debugMode: Boolean = false,
+        val errorMessage: String = "",
         val drawerState: ModalBottomSheetState = ModalBottomSheetState(
             ModalBottomSheetValue.Hidden,
             isSkipHalfExpanded = true
         ),
         val isDownloadingPlaylist: Boolean = false,
-        val downloadItemCount: Int = 0,
-        val currentIndex: Int = 0
+        val state: DownloadState = DownloadState()
     )
+
+    data class PlaylistSelectionViewState (
+        val showPlaylistSelectionDialog: Boolean = false,
+        val playlistSize: Int = 0,
+    )
+    private val playlistSelectionMutable = MutableStateFlow(PlaylistSelectionViewState())
+    val playlistSelectionState = playlistSelectionMutable.asStateFlow()
+
+    //Receive messages from the server
+    private val downloadHandler = object : Handler(Looper.getMainLooper()) {
+        override fun handleMessage(msg: Message) {
+            when (msg.what) {
+                WHAT_APPEND_TASK_ASK.ordinal -> {
+                    Log.i(TAG, "find device")
+                    if (!messageHasError(msg) && msg.arg1 > 1) {
+                        showPlaylistDialog(msg.arg1)
+                    }
+                }
+                WHAT_APPEND_TASK.ordinal -> {
+                    if (!messageHasError(msg)) {
+                        val task = messageHasParcel<DownloadTask>(msg)
+                        if (task != null) {
+                            viewModelScope.launch {
+                                TextUtil.makeToastSuspend(
+                                    context.getString(R.string.task_added).format(task.url)
+                                )
+                            }
+                        }
+                    }
+                }
+                WHAT_TASK_HALT.ordinal -> {
+                    if (!messageHasError(msg)) {
+                        val task = messageHasParcel<DownloadTask>(msg)
+                        if (task != null && task.url == stateFlow.value.url) {
+                            val b = msg.peekData()!!
+                            val stopOk = b.getBoolean(WHAT_TASK_HALT.name + "0")
+                            if (stopOk) {
+                                viewModelScope.launch {
+                                    TextUtil.makeToastSuspend(
+                                        context.getString(R.string.task_cancelled)
+                                            .format(task.url)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                WHAT_TASK_PROGRESS.ordinal -> {
+                    if (!messageHasError(msg)) {
+                        val downState = messageHasParcel<ServiceState>(msg)
+                        if (downState != null) {
+                            val b = msg.peekData()!!
+                            val isNewTask = b.getBoolean(WHAT_TASK_PROGRESS.name + "0")
+                            switchDownloadMode(downState.task!= null && downState.task.settings.isCustom())
+                            viewModelScope.launch {
+
+                                mutableStateFlow.update {
+                                    if (it.state.videoTitle != downState.state.videoTitle)
+                                        TextUtil.makeToastSuspend(context.getString(R.string.download_start_msg).format(
+                                            downState.state.videoTitle
+                                        ))
+                                    if (downState.task == null) {
+                                        if (isNewTask)
+                                            TextUtil.makeToastSuspend(context.getString(R.string.download_success_msg))
+                                        it.copy(
+                                            state = downState.state,
+                                            isProcessing = false,
+                                            isDownloadingPlaylist = false,
+                                            debugMode = PreferenceUtil.getValue(
+                                                PreferenceUtil.DEBUG)
+                                        )
+                                    }
+                                    else if (isNewTask) {
+                                        it.copy(
+                                            state = downState.state,
+                                            urlTask = downState.task.url,
+                                            isDownloadError = false,
+                                            isDownloadingPlaylist = downState.state.downloadItemCount-downState.state.currentIndex > 0,
+                                            isProcessing = true,
+                                            debugMode = PreferenceUtil.getValue(
+                                                PreferenceUtil.DEBUG)
+                                        )
+                                    }
+                                    else {
+                                        val proc = if (!it.isProcessing && it.state.progressText != downState.state.progressText) true else it.isProcessing
+                                        it.copy(
+                                            state = downState.state,
+                                            urlTask = downState.task.url,
+                                            isProcessing = proc,
+                                            isDownloadingPlaylist = downState.state.downloadItemCount-downState.state.currentIndex > 0,
+                                            debugMode = PreferenceUtil.getValue(
+                                                PreferenceUtil.DEBUG)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    private val mMessenger = Messenger(downloadHandler)
+
+    private inline fun <reified R: Parcelable> messageHasParcel(msg: Message): R? {
+        try {
+            val b = msg.peekData()
+            b.classLoader = R::class.java.classLoader
+            return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) b.getParcelable(values()[msg.what].name) else b.getParcelable(values()[msg.what].name, R::class.java)
+        }
+        catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return null
+    }
+
+    private fun messageHasError(msg: Message): Boolean {
+        if (msg.arg1 == -WHAT_ERROR.ordinal) {
+            viewModelScope.launch {
+                TextUtil.makeToastSuspend(context.getString(msg.arg2))
+                if (PreferenceUtil.getValue(PreferenceUtil.DEBUG)) {
+                    val b = msg.peekData()
+                    var errorMsg: String? = null
+                    if (b != null) {
+                        errorMsg = b.getString(WHAT_ERROR.name)
+                    }
+
+                    showErrorReport(errorMsg ?: context.getString(R.string.unknown_error))
+                }
+            }
+            return true
+        }
+        else
+            return false
+    }
+
 
     fun updateUrl(url: String) = mutableStateFlow.update { it.copy(url = url) }
 
@@ -71,314 +197,85 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    private var downloadResultTemp: DownloadUtil.Result = DownloadUtil.Result.failure()
 
-    private fun manageDownloadError(
-        e: Exception,
-        isFetchingInfo: Boolean = true,
-        notificationId: Int? = null
-    ) =
-        viewModelScope.launch {
-            e.printStackTrace()
-            if (PreferenceUtil.getValue(PreferenceUtil.DEBUG))
-                showErrorReport(e.message ?: context.getString(R.string.unknown_error))
-            else if (isFetchingInfo) showErrorMessage(context.getString(R.string.fetch_info_error_msg))
-            else showErrorMessage(context.getString(R.string.download_error_msg))
-            notificationId?.let {
-                NotificationUtil.finishNotification(
-                    notificationId, text = context.getString(R.string.download_error_msg),
-                )
-            }
-        }
-
-    private fun parsePlaylistInfo() {
-        viewModelScope.launch(Dispatchers.IO) {
-            if (!checkStateBeforeDownload()) return@launch
-            with(mutableStateFlow) {
-                if (value.url.isBlank()) {
-                    showErrorMessage(context.getString(R.string.url_empty))
-                    return@launch
-                }
-                update {
-                    it.copy(
-                        isDownloadError = false,
-                        isDownloadingPlaylist = false,
-                        isProcessing = true
-                    )
-                }
-                try {
-                    val playlistSize = DownloadUtil.getPlaylistSize(value.url)
-                    Log.d(TAG, playlistSize.toString())
-                    if (playlistSize == 1) downloadVideo(value.url)
-                    else showPlaylistDialog(playlistSize)
-                } catch (e: Exception) {
-                    manageDownloadError(e)
-                }
-            }
-        }
+    private fun sendDownloadMessage(startItem: Int = 0, endItem: Int = 0, what: Int = WHAT_APPEND_TASK.ordinal): DownloadTask {
+        val task = DownloadTask(if (what == WHAT_APPEND_TASK.ordinal) stateFlow.value.url else stateFlow.value.urlTask, startItem=startItem, endItem = endItem)
+        val m = Message.obtain(null, what)
+        m.replyTo = mMessenger
+        val b = Bundle()
+        b.putParcelable(values()[what].name, task)
+        m.data = b
+        BaseApplication.sendMessage(m)
+        return task
     }
 
-    fun downloadVideoInPlaylistByIndexRange(
-        url: String = stateFlow.value.url,
-        indexRange: IntRange
-    ) {
-        viewModelScope.launch(Dispatchers.IO) {
-            if (!checkStateBeforeDownload()) return@launch
-            mutableStateFlow.update {
-                it.copy(
-                    isDownloadingPlaylist = true,
-                    downloadItemCount = indexRange.last - indexRange.first + 1
-                )
-            }
-            for (index in indexRange) {
-                Log.d(TAG, stateFlow.value.isDownloadingPlaylist.toString())
-                if (!stateFlow.value.isDownloadingPlaylist) break
-                mutableStateFlow.update { it.copy(currentIndex = index - indexRange.first + 1) }
-                downloadVideo(url, index)
-            }
-            finishProcessing()
-        }
-    }
-
-    fun startDownloadVideo() {
-        switchDownloadMode(PreferenceUtil.getValue(PreferenceUtil.CUSTOM_COMMAND))
-        if (stateFlow.value.isInCustomCommandMode) {
-            downloadWithCustomCommands()
-            return
-        } else if (PreferenceUtil.getValue(PreferenceUtil.PLAYLIST)) {
-            parsePlaylistInfo()
-            return
-        }
-
+    fun startDownloadVideo(indexRange: IntRange = 0..0) {
         if (stateFlow.value.url.isBlank()) {
-            viewModelScope.launch { showErrorMessage(context.getString(R.string.url_empty)) }
+            viewModelScope.launch { TextUtil.makeToastSuspend(context.getString(R.string.url_empty)) }
             return
         }
-
-        viewModelScope.launch(Dispatchers.IO) {
-            if (!checkStateBeforeDownload()) return@launch
-            downloadVideo(stateFlow.value.url)
-            finishProcessing()
-        }
-    }
-
-    private suspend fun downloadVideo(url: String, index: Int = 1) {
-        with(mutableStateFlow) {
-
-            update { it.copy(isDownloadError = false) }
-
-            lateinit var videoInfo: VideoInfo
-            try {
-                videoInfo = DownloadUtil.fetchVideoInfo(url, index)
-            } catch (e: Exception) {
-                manageDownloadError(e)
-                return
-            }
-            Log.d(TAG, "downloadVideo: $index" + videoInfo.title)
-            update {
-                it.copy(
-                    progress = 0f,
-                    showVideoCard = true,
-                    videoTitle = videoInfo.title,
-                    videoAuthor = videoInfo.uploader ?: "null",
-                    videoThumbnailUrl = TextUtil.urlHttpToHttps(videoInfo.thumbnail ?: "")
-                )
-            }
-            val notificationId = (url + index).hashCode()
-            var intent: Intent? = null
-            try {
-                TextUtil.makeToastSuspend(
-                    context.getString(R.string.download_start_msg)
-                        .format(videoInfo.title)
-                )
-                NotificationUtil.makeNotification(notificationId, videoInfo.title)
-                downloadResultTemp =
-                    DownloadUtil.downloadVideo(videoInfo) { progress, _, line ->
-                        mutableStateFlow.update {
-                            it.copy(
-                                progress = progress,
-                                progressText = line
-                            )
-                        }
-                        NotificationUtil.updateNotification(
-                            notificationId,
-                            progress = progress.toInt(),
-                            text = line
-                        )
-                    }
-                intent = FileUtil.createIntentForOpenFile(downloadResultTemp)
-            } catch (e: Exception) {
-                manageDownloadError(e, false, notificationId)
-            }
-
-            NotificationUtil.finishNotification(
-                notificationId,
-                title = videoInfo.title,
-                text = context.getString(R.string.download_finish_notification),
-                intent = if (intent != null) PendingIntent.getActivity(
-                    context,
-                    0,
-                    FileUtil.createIntentForOpenFile(downloadResultTemp), FLAG_IMMUTABLE
-                ) else null
-            )
-        }
+        val task = sendDownloadMessage(indexRange.first, indexRange.last)
+        if (task.settings.downloadPlaylist && indexRange.first == 0 && indexRange.last == 0)
+            viewModelScope.launch { TextUtil.makeToastSuspend(context.getString(R.string.fetching_playlist_info)) }
     }
 
     private fun switchDownloadMode(enabled: Boolean) {
         with(mutableStateFlow) {
             if (enabled) {
-                update {
-                    it.copy(
-                        showVideoCard = false,
-                        isInCustomCommandMode = true,
-                    )
-                }
-            } else update { it.copy(isInCustomCommandMode = false) }
-        }
-    }
-
-    private fun downloadWithCustomCommands() {
-        val request = YoutubeDLRequest(stateFlow.value.url)
-        request.addOption("-P", "${BaseApplication.videoDownloadDir}/")
-        val m =
-            Pattern.compile(commandRegex)
-                .matcher(PreferenceUtil.getTemplate())
-        while (m.find()) {
-            if (m.group(1) != null) {
-                request.addOption(m.group(1))
-            } else {
-                request.addOption(m.group(2))
-            }
-        }
-        mutableStateFlow.update { it.copy(isDownloadError = false, progress = 0f) }
-        viewModelScope.launch(Dispatchers.IO) {
-            downloadResultTemp = DownloadUtil.Result.failure()
-            try {
-                if (stateFlow.value.url.isNotEmpty())
-                    with(DownloadUtil.fetchVideoInfo(stateFlow.value.url)) {
-                        if (!title.isNullOrEmpty() and !thumbnail.isNullOrEmpty())
-                            mutableStateFlow.update {
-                                it.copy(
-                                    videoTitle = title,
-                                    videoThumbnailUrl = TextUtil.urlHttpToHttps(thumbnail),
-                                    videoAuthor = uploader ?: "null",
-                                    showVideoCard = true
-                                )
-                            }
+                if (!stateFlow.value.isInCustomCommandMode || stateFlow.value.state.showVideoCard) {
+                    update {
+                        val st = it.state.copy(showVideoCard = false)
+                        it.copy(
+                            state = st,
+                            isInCustomCommandMode = true,
+                        )
                     }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-        val notificationId = stateFlow.value.url.hashCode()
-
-        TextUtil.makeToast(context.getString(R.string.start_execute))
-        NotificationUtil.makeNotification(
-            notificationId,
-            title = context.getString(R.string.execute_command_notification), text = ""
-        )
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                YoutubeDL.getInstance().execute(request) { progress, _, line ->
-                    mutableStateFlow.update { it.copy(progress = progress, progressText = line) }
-                    NotificationUtil.updateNotification(
-                        notificationId,
-                        progress = progress.toInt(),
-                        text = line
-                    )
                 }
-                finishProcessing()
-                NotificationUtil.finishNotification(
-                    notificationId,
-                    title = context.getString(R.string.download_success_msg),
-                    text = null,
-                    intent = null
-                )
-            } catch (e: Exception) {
-                manageDownloadError(e, false, notificationId)
-                return@launch
-            }
+            } else if (stateFlow.value.isInCustomCommandMode)
+                update { it.copy(isInCustomCommandMode = false) }
         }
-    }
-
-    private suspend fun checkStateBeforeDownload(): Boolean {
-        if (stateFlow.value.isProcessing) {
-            TextUtil.makeToastSuspend(context.getString(R.string.task_running))
-            return false
-        }
-        mutableStateFlow.update {
-            it.copy(
-                isProcessing = true, debugMode = PreferenceUtil.getValue(
-                    PreferenceUtil.DEBUG
-                )
-            )
-        }
-        return true
-    }
-
-    private suspend fun finishProcessing() {
-        mutableStateFlow.update {
-            it.copy(
-                progress = 100f,
-                isProcessing = false,
-                progressText = "",
-                downloadItemCount = 0,
-                isDownloadingPlaylist = false,
-                currentIndex = 0
-            )
-        }
-        TextUtil.makeToastSuspend(context.getString(R.string.download_success_msg))
     }
 
     private suspend fun showErrorReport(s: String) {
         TextUtil.makeToastSuspend(context.getString(R.string.error_copied))
         mutableStateFlow.update {
             it.copy(
-                progress = 0f,
                 isDownloadError = true,
                 errorMessage = s,
-                isProcessing = false, progressText = ""
-            )
-        }
-    }
-
-    private suspend fun showErrorMessage(s: String) {
-        TextUtil.makeToastSuspend(s)
-        mutableStateFlow.update {
-            it.copy(
-                progress = 0f,
-                isDownloadError = true,
-                errorMessage = s,
-                isProcessing = false, progressText = ""
+                isProcessing = false,
             )
         }
     }
 
 
     fun openVideoFile() {
-        if (mutableStateFlow.value.progress == 100f)
-            openFile(downloadResultTemp)
+        if (stateFlow.value.state.fileNames != null)
+            openFile(DownloadUtilService.Result.success(stateFlow.value.state.fileNames))
     }
 
     private fun showPlaylistDialog(playlistSize: Int) {
-        mutableStateFlow.update {
+        playlistSelectionMutable.update {
             it.copy(
-                showPlaylistSelectionDialog = true,
-                downloadItemCount = playlistSize, isProcessing = false
+                showPlaylistSelectionDialog = true, playlistSize = playlistSize
             )
         }
     }
 
     fun hidePlaylistDialog() {
-        mutableStateFlow.update { it.copy(showPlaylistSelectionDialog = false) }
+        playlistSelectionMutable.update { it.copy(showPlaylistSelectionDialog = false) }
     }
 
     fun stopDownloadPlaylistOnNextItem() {
-        mutableStateFlow.update { it.copy(isDownloadingPlaylist = false) }
+        sendDownloadMessage(what=WHAT_TASK_HALT.ordinal)
     }
 
     companion object {
         private const val TAG = "DownloadViewModel"
-        private const val commandRegex = "\"([^\"]*)\"|(\\S+)"
+    }
+
+    init {
+        val m = Message.obtain(null, WHAT_TASK_PROGRESS.ordinal)
+        m.replyTo = mMessenger
+        BaseApplication.sendMessage(m)
     }
 }

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionDialog.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionDialog.kt
@@ -28,18 +28,18 @@ import com.junkfood.seal.util.TextUtil.isNumberInRange
 @Composable
 fun PlaylistSelectionDialog(downloadViewModel: DownloadViewModel) {
 
-    val viewState = downloadViewModel.stateFlow.collectAsState().value
+    val viewState = downloadViewModel.playlistSelectionState.collectAsState().value
     val onDismissRequest = { downloadViewModel.hidePlaylistDialog() }
-    val playlistItemCount = viewState.downloadItemCount
+    val playlistItemCount = viewState.playlistSize
     var from by remember { mutableStateOf(1.toString()) }
-    var to by remember { mutableStateOf(viewState.downloadItemCount.toString()) }
+    var to by remember { mutableStateOf(viewState.playlistSize.toString()) }
 
     var error by remember { mutableStateOf(false) }
     val (item1, item2) = remember { FocusRequester.createRefs() }
 
     if (viewState.showPlaylistSelectionDialog) {
         from = "1"
-        to = viewState.downloadItemCount.toString()
+        to = viewState.playlistSize.toString()
         AlertDialog(onDismissRequest = {}, icon = { Icon(Icons.Outlined.PlaylistPlay, null) },
             title = { Text(stringResource(R.string.download_range_selection)) },
             text = {
@@ -114,7 +114,7 @@ fun PlaylistSelectionDialog(downloadViewModel: DownloadViewModel) {
                     ) || from.toInt() > to.toInt()
                     if (error) TextUtil.makeToast(R.string.invalid_index_range)
                     else {
-                        downloadViewModel.downloadVideoInPlaylistByIndexRange(indexRange = from.toInt()..to.toInt())
+                        downloadViewModel.startDownloadVideo(indexRange = from.toInt()..to.toInt())
                         onDismissRequest()
                     }
                 }) {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/download/DownloadPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/download/DownloadPreferences.kt
@@ -22,6 +22,7 @@ import com.junkfood.seal.R
 import com.junkfood.seal.ui.component.PreferenceItem
 import com.junkfood.seal.ui.component.PreferenceSwitch
 import com.junkfood.seal.ui.component.Subtitle
+import com.junkfood.seal.ui.page.download.DownloadViewModel
 import com.junkfood.seal.util.PreferenceUtil
 import com.junkfood.seal.util.PreferenceUtil.CUSTOM_COMMAND
 import com.junkfood.seal.util.PreferenceUtil.DEBUG
@@ -41,7 +42,7 @@ import kotlinx.coroutines.launch
     ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class
 )
 @Composable
-fun DownloadPreferences(onBackPressed: () -> Unit, navigateToDownloadDirectory: () -> Unit) {
+fun DownloadPreferences(downloadViewModel: DownloadViewModel, onBackPressed: () -> Unit, navigateToDownloadDirectory: () -> Unit) {
     val context = LocalContext.current
 
     var showTemplateEditDialog by remember { mutableStateOf(false) }
@@ -58,7 +59,7 @@ fun DownloadPreferences(onBackPressed: () -> Unit, navigateToDownloadDirectory: 
         mutableStateOf(PreferenceUtil.getValue(NOTIFICATION))
     }
 
-    val ytdlpVersion = BaseApplication.ytdlpVersion.collectAsState()
+    val ytdlpVersion = downloadViewModel.ytdlpVersion.collectAsState()
 
     val notificationPermission =
         if (Build.VERSION.SDK_INT >= 33)
@@ -133,7 +134,7 @@ fun DownloadPreferences(onBackPressed: () -> Unit, navigateToDownloadDirectory: 
                         description = ytdlpVersion.value,
                         icon = Icons.Outlined.Update
                     ) {
-                        BaseApplication.updateytDlp(true)
+                        downloadViewModel.updateytDlp(true)
                     }
                 }
                 item {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/download/DownloadPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/download/DownloadPreferences.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
-import com.junkfood.seal.BaseApplication
 import com.junkfood.seal.R
 import com.junkfood.seal.ui.component.PreferenceItem
 import com.junkfood.seal.ui.component.PreferenceSwitch
@@ -34,9 +33,6 @@ import com.junkfood.seal.util.PreferenceUtil.getAudioFormatDesc
 import com.junkfood.seal.util.PreferenceUtil.getVideoFormatDesc
 import com.junkfood.seal.util.PreferenceUtil.getVideoQualityDesc
 import com.junkfood.seal.util.TextUtil
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 
 @OptIn(
     ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/download/DownloadPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/download/DownloadPreferences.kt
@@ -22,7 +22,6 @@ import com.junkfood.seal.R
 import com.junkfood.seal.ui.component.PreferenceItem
 import com.junkfood.seal.ui.component.PreferenceSwitch
 import com.junkfood.seal.ui.component.Subtitle
-import com.junkfood.seal.util.DownloadUtil
 import com.junkfood.seal.util.PreferenceUtil
 import com.junkfood.seal.util.PreferenceUtil.CUSTOM_COMMAND
 import com.junkfood.seal.util.PreferenceUtil.DEBUG
@@ -58,6 +57,8 @@ fun DownloadPreferences(onBackPressed: () -> Unit, navigateToDownloadDirectory: 
     var downloadNotification by remember {
         mutableStateOf(PreferenceUtil.getValue(NOTIFICATION))
     }
+
+    val ytdlpVersion = BaseApplication.ytdlpVersion.collectAsState()
 
     val notificationPermission =
         if (Build.VERSION.SDK_INT >= 33)
@@ -127,17 +128,12 @@ fun DownloadPreferences(onBackPressed: () -> Unit, navigateToDownloadDirectory: 
                     ) { navigateToDownloadDirectory() }
                 }
                 item {
-                    var ytdlpVersion by remember {
-                        mutableStateOf(BaseApplication.ytdlpVersion)
-                    }
                     PreferenceItem(
                         title = stringResource(id = R.string.ytdlp_version),
-                        description = ytdlpVersion,
+                        description = ytdlpVersion.value,
                         icon = Icons.Outlined.Update
                     ) {
-                        CoroutineScope(Job()).launch {
-                            ytdlpVersion = DownloadUtil.updateYtDlp()
-                        }
+                        BaseApplication.updateytDlp(true)
                     }
                 }
                 item {

--- a/app/src/main/java/com/junkfood/seal/util/DownloadState.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadState.kt
@@ -1,0 +1,68 @@
+package com.junkfood.seal.util
+
+import android.os.Parcelable
+import com.junkfood.seal.BaseApplication
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class DownloadState (
+    val progress: Float = 0f,
+    val videoTitle: String = "",
+    val showVideoCard: Boolean = false,
+    val videoThumbnailUrl: String = "",
+    val videoAuthor: String = "",
+    val progressText: String = "",
+    val downloadItemCount: Int = 0,
+    val currentIndex: Int = 0,
+    val fileNames: List<String>? = null,
+): Parcelable
+
+@Parcelize
+data class TaskSettings(
+    val downloadPlaylist: Boolean =  false,
+    val extractAudio: Boolean = false,
+    val createThumbnail: Boolean = false,
+    val concurrentFragments: Float = 0f,
+    val videoDownloadDir: String = "",
+    val audioDownloadDir: String = "",
+    val subdirectory: Boolean = false,
+    val videoQuality: Int = 1,
+    val videoFormat: Int = 1,
+    val audioFormat: Int = 1,
+    val command: String? = null,
+): Parcelable {
+    fun isCustom(): Boolean {
+        return command != null && command.isNotEmpty()
+    }
+    companion object {
+        fun fromSettings():  TaskSettings{
+            return TaskSettings(
+                downloadPlaylist = PreferenceUtil.getValue(PreferenceUtil.PLAYLIST),
+                extractAudio = PreferenceUtil.getValue(PreferenceUtil.EXTRACT_AUDIO),
+                createThumbnail = PreferenceUtil.getValue(PreferenceUtil.THUMBNAIL),
+                concurrentFragments = PreferenceUtil.getConcurrentFragments(),
+                videoDownloadDir = BaseApplication.videoDownloadDir,
+                audioDownloadDir = BaseApplication.audioDownloadDir,
+                subdirectory = PreferenceUtil.getValue(PreferenceUtil.SUBDIRECTORY),
+                videoQuality = PreferenceUtil.getVideoQuality(),
+                audioFormat = PreferenceUtil.getAudioFormat(),
+                videoFormat = PreferenceUtil.getVideoFormat(),
+                command = if (PreferenceUtil.getValue(PreferenceUtil.CUSTOM_COMMAND)) PreferenceUtil.getTemplate() else null,
+            )
+        }
+    }
+}
+
+@Parcelize
+data class DownloadTask(
+    val url: String,
+    val startItem: Int = 0,
+    val endItem: Int = 0,
+    val settings: TaskSettings = TaskSettings.fromSettings(),
+): Parcelable
+
+@Parcelize
+data class ServiceState (
+    val task: DownloadTask? = null,
+    val state: DownloadState = DownloadState()
+): Parcelable

--- a/app/src/main/java/com/junkfood/seal/util/FileUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/FileUtil.kt
@@ -11,8 +11,8 @@ import java.io.File
  * Sorry for ugly codes for filename control
  */
 object FileUtil {
-    fun openFile(downloadResult: DownloadUtil.Result) {
-        if (downloadResult.resultCode == DownloadUtil.ResultCode.EXCEPTION) return
+    fun openFile(downloadResult: DownloadUtilService.Result) {
+        if (downloadResult.resultCode == DownloadUtilService.ResultCode.EXCEPTION) return
         openFileInURI(downloadResult.filePath?.get(0) ?: return)
     }
 
@@ -41,8 +41,25 @@ object FileUtil {
         }
     }
 
-    fun createIntentForOpenFile(downloadResult: DownloadUtil.Result): Intent? {
-        if (downloadResult.resultCode == DownloadUtil.ResultCode.EXCEPTION || downloadResult.filePath?.isEmpty() == true) return null
+    fun createIntentForOpenFile(downloadResult: DownloadUtilService.Result): Intent? {
+        if (downloadResult.resultCode == DownloadUtilService.ResultCode.EXCEPTION || downloadResult.filePath?.isEmpty() == true) return null
+        val path = downloadResult.filePath?.first() ?: return null
+        return Intent().apply {
+            action = (Intent.ACTION_VIEW)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+            setDataAndType(
+                FileProvider.getUriForFile(
+                    context,
+                    context.packageName + ".provider",
+                    File(path)
+                ),
+                if (path.contains(Regex("\\.mp3|\\.m4a|\\.opus"))) "audio/*" else "video/*"
+            )
+        }
+    }
+
+    fun createIntentForOpenFileService(downloadResult: DownloadUtilService.Result): Intent? {
+        if (downloadResult.resultCode == DownloadUtilService.ResultCode.EXCEPTION || downloadResult.filePath?.isEmpty() == true) return null
         val path = downloadResult.filePath?.first() ?: return null
         return Intent().apply {
             action = (Intent.ACTION_VIEW)

--- a/app/src/main/res/drawable/ic_baseline_close_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_close_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,4 +152,10 @@
     <string name="permission_issue_desc">Directories outside Download/ and Documents/ are not supported</string>
     <string name="battery_configuration">Battery configuration</string>
     <string name="battery_configuration_desc">Ignore battery optimization for this app to download in background</string>
+    <string name="seal_service">Seal Video Download Service</string>
+    <string name="btn_stop">Stop</string>
+    <string name="seal_service_running">Running</string>
+    <string name="invalid_task_error">Cannot add task: invalid!</string>
+    <string name="task_added">Task Added for url %1$s</string>
+    <string name="task_cancelled">Task Cancelled for url %1$s</string>
 </resources>


### PR DESCRIPTION
Hi
I implemented the foreground video downloading service.
It is responsible for all the calls to the YTDL. It communicates with the UI via the Messenger / Handler class. While downloading the UI can be closed. When reopened, the UI will rebind to the service and show the download progress. Multiple download tasks can be queued by the service that will perform the downloads one by one. The foreground service will be started (if not already started) at application start and can be stopped via its notification button.
It is quite a massive change but I think it is required to avoid application kill.