### PR TITLE
Fix for stop service button in notification

### DIFF
--- a/app/src/main/java/com/junkfood/seal/BaseApplication.kt
+++ b/app/src/main/java/com/junkfood/seal/BaseApplication.kt
@@ -2,11 +2,11 @@ package com.junkfood.seal
 
 import android.annotation.SuppressLint
 import android.app.Application
-import android.content.*
-import android.os.*
-import android.util.Log
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.os.Environment
 import com.google.android.material.color.DynamicColors
-import com.junkfood.seal.service.VideoDownloadService
 import com.junkfood.seal.util.NotificationUtil
 import com.junkfood.seal.util.PreferenceUtil
 import com.junkfood.seal.util.PreferenceUtil.AUDIO_DIRECTORY
@@ -42,23 +42,17 @@ class BaseApplication : Application() {
             audioDownloadDir = if (isNullOrEmpty()) File(videoDownloadDir, "Audio").absolutePath
             else this
         }
-        bindServiceInvoked()
         if (Build.VERSION.SDK_INT >= 26)
             NotificationUtil.createNotificationChannel()
     }
 
     companion object {
         private const val TAG = "BaseApplication"
-        var mService: Messenger? = null
-        var messageToSend: Message? = null
         lateinit var clipboard: ClipboardManager
         lateinit var videoDownloadDir: String
         lateinit var audioDownloadDir: String
         lateinit var applicationScope: CoroutineScope
-        private var isBinding = false
-        private val intentToService by lazy {
-            Intent(context, VideoDownloadService::class.java)
-        }
+
         fun updateDownloadDir(path: String, isAudio: Boolean = false) {
             if (isAudio) {
                 audioDownloadDir = path
@@ -66,54 +60,6 @@ class BaseApplication : Application() {
             } else {
                 videoDownloadDir = path
                 PreferenceUtil.updateString(VIDEO_DIRECTORY, path)
-            }
-        }
-
-        fun sendMessage(m: Message) {
-            if (mService == null) {
-                messageToSend = m
-                bindServiceInvoked()
-            }
-            else
-                mService!!.send(m)
-        }
-
-        //Receive service connection and disconnection messages
-        private val serviceConnection: ServiceConnection = object : ServiceConnection {
-            override fun onServiceConnected(name: ComponentName, service: IBinder) {
-                Log.i(TAG, "service connected")
-                isBinding = false
-                mService = Messenger(service)
-
-                //Since the server does not have the client's messenger after binding, send the client's messenger to the server after binding
-                if (mService != null) {
-                    try {
-                        if (messageToSend != null) {
-                            sendMessage(messageToSend!!)
-                            messageToSend = null
-                        }
-                    } catch (e: RemoteException) {
-                        e.printStackTrace()
-                    }
-                }
-            }
-
-            override fun onServiceDisconnected(name: ComponentName) {
-                Log.i("client", "service disconnected")
-                mService = null
-                isBinding = false
-            }
-
-            override fun onBindingDied(name: ComponentName?) {
-                mService = null
-                isBinding = false
-            }
-        }
-
-        private fun bindServiceInvoked() {
-            if (!isBinding) {
-                isBinding = true
-                context.bindService(intentToService, serviceConnection, BIND_AUTO_CREATE)
             }
         }
 

--- a/app/src/main/java/com/junkfood/seal/MainActivity.kt
+++ b/app/src/main/java/com/junkfood/seal/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.junkfood.seal
 
+import android.content.ComponentName
 import android.content.Intent
-import android.os.Bundle
+import android.content.ServiceConnection
+import android.os.*
 import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -10,6 +12,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import com.junkfood.seal.service.VideoDownloadService
 import com.junkfood.seal.ui.page.HomeEntry
 import com.junkfood.seal.ui.page.download.DownloadViewModel
 import com.junkfood.seal.util.PreferenceUtil
@@ -18,6 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlin.system.exitProcess
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -28,6 +32,7 @@ class MainActivity : AppCompatActivity() {
             AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(PreferenceUtil.getLanguageConfiguration()))
         }
         super.onCreate(savedInstanceState)
+        instance = this
         WindowCompat.setDecorFitsSystemWindows(window, false)
         ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { v, insets ->
             v.setPadding(0, 0, 0, 0)
@@ -38,6 +43,22 @@ class MainActivity : AppCompatActivity() {
             HomeEntry(downloadViewModel)
         }
         handleShareIntent(intent)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        bindServiceInvoked()
+    }
+
+    override fun onStop() {
+        mService = null
+        baseContext.unbindService(serviceConnection)
+        super.onStop()
+    }
+
+    override fun onDestroy() {
+        instance = null
+        super.onDestroy()
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -63,13 +84,71 @@ class MainActivity : AppCompatActivity() {
     companion object {
         private const val TAG = "MainActivity"
         private var sharedUrl = ""
+        var mService: Messenger? = null
+        var messageToSend: Message? = null
+        private var instance: MainActivity? = null
+        private var isBinding = false
+
+        fun sendMessage(m: Message) {
+            if (mService == null) {
+                messageToSend = m
+                bindServiceInvoked()
+            }
+            else
+                mService!!.send(m)
+        }
+
+        //Receive service connection and disconnection messages
+        private val serviceConnection: ServiceConnection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName, service: IBinder) {
+                Log.i(TAG, "service connected")
+                isBinding = false
+                mService = Messenger(service)
+
+                //Since the server does not have the client's messenger after binding, send the client's messenger to the server after binding
+                if (mService != null) {
+                    try {
+                        if (messageToSend != null) {
+                            sendMessage(messageToSend!!)
+                            messageToSend = null
+                        }
+                    } catch (e: RemoteException) {
+                        e.printStackTrace()
+                    }
+                }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName) {
+                Log.i("client", "service disconnected")
+                mService = null
+                isBinding = false
+            }
+
+            override fun onBindingDied(name: ComponentName?) {
+                mService = null
+                isBinding = false
+            }
+        }
+
+        private fun bindServiceInvoked() {
+            if (!isBinding && instance != null) {
+                isBinding = true
+                instance!!.baseContext.bindService(Intent(instance!!.baseContext, VideoDownloadService::class.java), serviceConnection, BIND_AUTO_CREATE)
+            }
+        }
         fun setLanguage(locale: String) {
             if (locale.isEmpty()) return
             BaseApplication.applicationScope.launch(Dispatchers.Main) {
                 AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(locale))
             }
         }
-
+        fun exit(code: Int = 0) {
+            BaseApplication.applicationScope.launch(Dispatchers.Main) {
+                if (instance != null)
+                    instance!!.finish()
+                exitProcess(code)
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/junkfood/seal/MainActivity.kt
+++ b/app/src/main/java/com/junkfood/seal/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
 import com.junkfood.seal.service.VideoDownloadService
 import com.junkfood.seal.ui.page.HomeEntry
 import com.junkfood.seal.ui.page.download.DownloadViewModel
@@ -131,7 +132,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         private fun bindServiceInvoked() {
-            if (!isBinding && instance != null) {
+            if (!isBinding && instance != null && instance!!.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
                 isBinding = true
                 instance!!.baseContext.bindService(Intent(instance!!.baseContext, VideoDownloadService::class.java), serviceConnection, BIND_AUTO_CREATE)
             }

--- a/app/src/main/java/com/junkfood/seal/service/Constants.kt
+++ b/app/src/main/java/com/junkfood/seal/service/Constants.kt
@@ -1,10 +1,7 @@
 package com.junkfood.seal.service
 
 object Constants {
-    const val ACTION_NOTIFICATION_NAME = "ACTION_NOTIFICATION_NAME"
-    const val ACTION_START = "START"
     const val ACTION_STOP = "STOP"
-    const val ACTION_NOTIFICATION_KEY = "ACTION_NOTIFICATION_KEY"
     const val NOTIFICATION_ID = 123
     const val CHANNEL_ID = "SealVideoService"
     const val NO_ERROR = -1
@@ -14,6 +11,7 @@ object Constants {
         WHAT_TASK_HALT,
         WHAT_APPEND_TASK_ASK,
         WHAT_TASK_PROGRESS,
+        WHAT_EXIT_REQUEST,
         WHAT_ERROR,
     }
 }

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/DownloadViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.junkfood.seal.BaseApplication
 import com.junkfood.seal.BaseApplication.Companion.context
+import com.junkfood.seal.MainActivity
 import com.junkfood.seal.R
 import com.junkfood.seal.service.Constants.What.*
 import com.junkfood.seal.util.*
@@ -65,7 +66,7 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
             val m = Message.obtain(null, WHAT_YTDLP_VERSION.ordinal)
             m.replyTo = mMessenger
             m.data = b
-            BaseApplication.sendMessage(m)
+            MainActivity.sendMessage(m)
         }
         else
             ytdlpVersionM.update { s }
@@ -80,6 +81,9 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
                     if (!messageHasError(msg) && msg.arg1 > 1) {
                         showPlaylistDialog(msg.arg1)
                     }
+                }
+                WHAT_EXIT_REQUEST.ordinal -> {
+                    MainActivity.exit(0)
                 }
                 WHAT_YTDLP_VERSION.ordinal -> {
                     Log.i(TAG, "ver ok")
@@ -233,7 +237,7 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
         val b = Bundle()
         b.putParcelable(values()[what].name, task)
         m.data = b
-        BaseApplication.sendMessage(m)
+        MainActivity.sendMessage(m)
         return task
     }
 
@@ -305,6 +309,6 @@ class DownloadViewModel @Inject constructor() : ViewModel() {
         val m = Message.obtain(null, WHAT_TASK_PROGRESS.ordinal)
         updateytDlp()
         m.replyTo = mMessenger
-        BaseApplication.sendMessage(m)
+        MainActivity.sendMessage(m)
     }
 }


### PR DESCRIPTION
Now stop service button should only show when needed (during download task and when the app is unbound to the service). Using the button will cause the app to exit too.
I had to move service management under MainActivity class to make this work reliably (detect app stop and show service close button)