### PR TITLE
Corrected the Arabic language name.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,7 +164,7 @@
     <string name="la_es" translatable="false">Español</string>
     <string name="la_tr" translatable="false">Türkçe</string>
     <string name="la_ru" translatable="false">Русский</string>
-    <string name="la_ar" translatable="false">عربي</string>
+    <string name="la_ar" translatable="false">العربية</string>
     <string name="la_uk" translatable="false">Українська</string>
     <string name="la_in" translatable="false">Indonesia</string>
     <string name="la_fa" translatable="false">فارسی</string>


### PR DESCRIPTION
`عربي` = `Arab` (a person whose language is Arabic) `العربية` = `Arabic` (the language)

_______________________________________________________________________________

I didn't notice it till a user by the name `A B` make me aware of it in Telegram.