### PR TITLE
Action to handle Meta issues

### DIFF
--- a/.github/workflows/MetaIssueHandler.yaml
+++ b/.github/workflows/MetaIssueHandler.yaml
@@ -88,23 +88,31 @@ jobs:
 
           script: |
 
-            const q = 'instagram in:body label:bug repo:${{ github.repository }} OR facebook in:body label:bug repo:${{ github.repository }}';
+            const q = 'instagram in:body label:bug repo:${{ github.repository }} OR facebook in:body label:bug repo:${{ github.repository }} state:open';
 
             github.paginate(github.search.issuesAndPullRequests, { q }, (response) => {
 
               response.data.forEach(async issue => {
 
-                await github.issues.addLabels({
+                const labels = issue.labels.map(label => label.name);
 
-                  issue_number: issue.number,
+              
 
-                  owner: context.repo.owner,
+                if (!labels.includes('wontfix')) {
 
-                  repo: context.repo.repo,
+                  await github.issues.addLabels({
 
-                  labels: ['wontfix']
+                    issue_number: issue.number,
 
-                });
+                    owner: context.repo.owner,
+
+                    repo: context.repo.repo,
+
+                    labels: ['wontfix']
+
+                  });
+
+                }
 
                 await github.issues.update({
 
@@ -133,3 +141,4 @@ jobs:
               })
 
             })
+

--- a/.github/workflows/MetaIssueHandler.yaml
+++ b/.github/workflows/MetaIssueHandler.yaml
@@ -1,0 +1,135 @@
+on:
+
+  issues:
+
+    types: [opened, labeled]
+
+  workflow_dispatch:
+
+jobs:
+
+  auto_close_issues:
+
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event_name == 'issues' }}
+
+    steps:
+
+      - name: 'Close issue and add wontfix label'
+
+        uses: actions/github-script@v3
+
+        with:
+
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
+          script: |
+
+            const issueBody = context.payload.issue.body;
+
+            const labels = context.payload.issue.labels.map(label => label.name);
+
+            if ((issueBody.includes('instagram') || issueBody.includes('facebook')) && labels.includes('bug')) {
+
+              await github.issues.update({
+
+                issue_number: context.issue.number,
+
+                owner: context.repo.owner,
+
+                repo: context.repo.repo,
+
+                state: 'closed'
+
+              });
+
+              await github.issues.addLabels({
+
+                issue_number: context.issue.number,
+
+                owner: context.repo.owner,
+
+                repo: context.repo.repo,
+
+                labels: ['wontfix']
+
+              });
+
+              await github.issues.createComment({
+
+                issue_number: context.issue.number,
+
+                owner: context.repo.owner,
+
+                repo: context.repo.repo,
+
+                body: 'Please check issue https://github.com/JunkFood02/Seal/issues/733 for more info.'
+
+              });
+
+            }
+
+  label_and_close_old_issues:
+
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+
+    steps:
+
+      - name: 'Label and close old issues'
+
+        uses: actions/github-script@v3
+
+        with:
+
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
+          script: |
+
+            const q = 'instagram in:body label:bug repo:${{ github.repository }} OR facebook in:body label:bug repo:${{ github.repository }}';
+
+            github.paginate(github.search.issuesAndPullRequests, { q }, (response) => {
+
+              response.data.forEach(async issue => {
+
+                await github.issues.addLabels({
+
+                  issue_number: issue.number,
+
+                  owner: context.repo.owner,
+
+                  repo: context.repo.repo,
+
+                  labels: ['wontfix']
+
+                });
+
+                await github.issues.update({
+
+                  issue_number: issue.number,
+
+                  owner: context.repo.owner,
+
+                  repo: context.repo.repo,
+
+                  state: 'closed'
+
+                });
+
+                await github.issues.createComment({
+
+                  issue_number: issue.number,
+
+                  owner: context.repo.owner,
+
+                  repo: context.repo.repo,
+
+                  body: 'Please check issue https://github.com/JunkFood02/Seal/issues/733 for more info.'
+
+                });
+
+              })
+
+            })


### PR DESCRIPTION
# Meta_Isuues_Handler

This pull request introduces a new GitHub Actions workflow to automate certain aspects of the issue management process. The workflow consists of two jobs: `auto_close_issues` and `label_and_close_old_issues`.

The auto_close_issues job is triggered whenever an issue is opened or labeled. It checks if the body of the issue contains either the word 'Instagram' or 'Facebook' and if it has been labeled as a 'bug'. If both conditions are met, the issue is automatically closed, a 'wontfix' label is added, and a comment is made to direct the user to issue #733 for more information.

The label_and_close_old_issues job can be manually triggered. When run, it searches for all issues in the repository that are labeled as 'bug' and contain either 'Instagram' or 'Facebook' in their body. For each such issue found, the job automatically adds a 'wontfix' label, closes the issue, and leaves a comment directing the user to issue #733 for more information.