### PR TITLE
fix: add `if` conditional in `sponsor.yml`

### DIFF
--- a/.github/workflows/sponsor.yml
+++ b/.github/workflows/sponsor.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'JunkFood02/Seal' }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2


### PR DESCRIPTION
In `sponsor.yml`, `Generate Sponsors README` is set to run regularly even in forked repos,  which have no secrets needed. This might be confusing since GitHub sends E-mail for every failed Action.

I added `if` in `sponsor.yml` to prevent running in forked repos.