### PR TITLE
Update android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,37 +4,41 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
 
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
+    - name: set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: 'gradle'
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
 
-      - uses: gradle/actions/setup-gradle@v3
-      - run: gradle assembleRelease
+    - uses: gradle/actions/setup-gradle@v3
 
-      - uses: ilharp/sign-android-release@v1
-        name: Sign app APK
-        id: sign_app
-        with:
-          releaseDir: app/build/outputs/apk/release
-          signingKey: ${{ secrets.SIGNING_KEY }}
-          keyAlias: ${{ secrets.ALIAS }}
-          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
-          keyPassword: ${{ secrets.KEY_PASSWORD }}
+    - run: gradle assembleRelease
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Signed apks
-          path: app/build/outputs/apk/release/*-arm64-v8a-release-signed.apk
+    - name: Sign app APK
+      id: sign_app
+      uses: ilharp/sign-android-release@nightly
+      with:
+        releaseDir: app/build/outputs/apk/release
+        signingKey: ${{ secrets.SIGNING_KEY }}
+        keyAlias: ${{ secrets.ALIAS }}
+        keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+        keyPassword: ${{ secrets.KEY_PASSWORD }}
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: signed-apks
+        path: app/build/outputs/apk/release/*-arm64-v8a-release-signed.apk
+        if-no-files-found: error
+        retention-days: 20


### PR DESCRIPTION
# Updates!
- Updated the `upload-artifact` action to v4, since v3 is now deprecated.
- Updated the `setup-java` to v4 and pumped java-version to `21`.
- The uploaded artifacts will be now deleted after 20 days.
- The following warnings should be gone:
> [!WARNING]
>
>  - `Node.js 16 actions are deprecated`
>  - `The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled > for deprecation: "Signed apks".
> Please update your workflow to use v4 of the artifact actions.
> Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/`