### PR TITLE
Compose buildFeature flag could be removed after AGP 8.5.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,10 +183,6 @@ android {
         }
     }
 
-    buildFeatures {
-        compose = true
-    }
-
     lint {
         disable.addAll(listOf("MissingTranslation", "ExtraTranslation", "MissingQuantity"))
     }

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -21,9 +21,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         sourceCompatibility = JavaVersion.VERSION_1_8
     }
-    buildFeatures {
-        compose = true
-    }
     buildTypes {
         all {
             proguardFiles(


### PR DESCRIPTION
It will be enabled after `org.jetbrains.kotlin.plugin.compose` is applied.