### PR TITLE
build: migrate to room gradle plugin

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,9 @@ android {
     room {
         schemaDirectory("$projectDir/schemas")
     }
-
+    ksp {
+        arg("room.incremental", "true") //Still not supported by the Room plugin
+    }
     val abiCodes = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86" to 3, "x86_64" to 4)
 
     androidComponents {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.room)
 }
 
 val keystorePropertiesFile: File = rootProject.file("keystore.properties")
@@ -39,7 +40,7 @@ android {
         applicationId = "com.junkfood.seal"
         minSdk = 24
         targetSdk = 34
-        versionCode = rootProject.extra["versionCode"] as Int
+        versionCode = 20000 // (rootProject.extra["versionCode"] as Int) -- Can't be used because of F-droid
 
         if (splitApks) {
             splits {
@@ -60,16 +61,17 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        ksp {
-            arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
-            arg("room.incremental", "true")
-        }
+
         if (!splitApks) {
             ndk {
                 abiFilters.addAll(abiFilterList)
             }
         }
     }
+    room {
+        schemaDirectory("$projectDir/schemas")
+    }
+
     val abiCodes = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86" to 3, "x86_64" to 4)
 
     androidComponents {
@@ -199,16 +201,4 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.espresso.core)
     implementation(libs.androidx.compose.ui.tooling)
-}
-
-class RoomSchemaArgProvider(
-    @get:InputDirectory @get:PathSensitive(PathSensitivity.RELATIVE) val schemaDir: File
-) : CommandLineArgumentProvider {
-
-    override fun asArguments(): Iterable<String> {
-        if (!schemaDir.exists()) {
-            schemaDir.mkdirs()
-        }
-        return listOf("room.schemaLocation=${schemaDir.path}")
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,3 @@
-@file:Suppress("UnstableApiUsage")
-
-buildscript {
-
-    repositories {
-        mavenCentral()
-        google()
-    }
-}
-
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
@@ -18,7 +7,72 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
 }
 
+buildscript {
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
+
+sealed class Version(
+    open val versionMajor: Int,
+    val versionMinor: Int,
+    val versionPatch: Int,
+    val versionBuild: Int = 0
+) {
+    abstract fun toVersionName(): String
+
+    fun toVersionCode(): Int {
+        val minor = versionMinor.toString().padStart(2, '0')
+        val patch = versionPatch.toString().padStart(2, '0')
+
+        // Combining the version components, ensuring the result is 5 digits
+        // We suppose that the major version won't be greater than 9
+        return "$versionMajor$minor$patch".toInt()
+    }
+
+
+    class Alpha(versionMajor: Int, versionMinor: Int, versionPatch: Int, versionBuild: Int) :
+        Version(versionMajor, versionMinor, versionPatch, versionBuild) {
+        override fun toVersionName(): String =
+            "${versionMajor}.${versionMinor}.${versionPatch}-alpha.$versionBuild"
+    }
+
+    class Beta(versionMajor: Int, versionMinor: Int, versionPatch: Int, versionBuild: Int) :
+        Version(versionMajor, versionMinor, versionPatch, versionBuild) {
+        override fun toVersionName(): String =
+            "${versionMajor}.${versionMinor}.${versionPatch}-beta.$versionBuild"
+    }
+
+    class Stable(versionMajor: Int, versionMinor: Int, versionPatch: Int) :
+        Version(versionMajor, versionMinor, versionPatch) {
+        override fun toVersionName(): String =
+            "${versionMajor}.${versionMinor}.${versionPatch}"
+    }
+
+    class ReleaseCandidate(
+        versionMajor: Int,
+        versionMinor: Int,
+        versionPatch: Int,
+        versionBuild: Int
+    ) :
+        Version(versionMajor, versionMinor, versionPatch, versionBuild) {
+        override fun toVersionName(): String =
+            "${versionMajor}.${versionMinor}.${versionPatch}-rc.$versionBuild"
+    }
+}
+
+val currentVersion: Version = Version.Alpha(
+    versionMajor = 2,
+    versionMinor = 0,
+    versionPatch = 0,
+    versionBuild = 2
+)
+
+val versionCode by extra(currentVersion.toVersionCode())
+val versionName by extra(currentVersion.toVersionName())
+
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.room) apply false
 }
 
 buildscript {

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -37,5 +37,4 @@ dependencies {
     api(libs.androidx.core.ktx)
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.material3)
-
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidxSplashscreen = "1.0.1"
 androidxLifecycle = "2.8.4"
 androidxNavigation = "2.7.7"
 androidxFoundation = "1.6.0-beta03"
-androidxComposeMaterial3 = "1.2.0-beta01"
+androidxComposeMaterial3 = "1.3.0-alpha06"
 androidxComposeAnimation = "1.5.0-beta01"
 
 androidxEspresso = "3.5.0"
@@ -62,7 +62,7 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 
 androidx-compose-material = { group = "androidx.compose.material", name = "material" }
 
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.3.0-alpha06" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxComposeMaterial3" }
 androidx-compose-material3-windowSizeClass = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
@@ -110,6 +110,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+room = { id = "androidx.room", version.ref = "room" }
 
 [bundles]
 accompanist = [


### PR DESCRIPTION
This commit updates the versioning logic. The `toVersionCode` function is also added to the `Version` class to calculate the version code based on the version components.
 - Added Room schemas folder creation when it doesn't exist
 - Updated deprecated code for the `clean` Gradle task