### PR TITLE
refactor(ui): Use AutoMirrored icons and migrated deprecated components

### DIFF
--- a/app/src/main/java/com/junkfood/seal/ui/component/Buttons.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/component/Buttons.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.OpenInNew
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
@@ -172,7 +173,7 @@ fun DismissButton(text: String = stringResource(R.string.dismiss), onClick: () -
 fun LinkButton(
     modifier: Modifier = Modifier,
     text: String = stringResource(R.string.yt_dlp_docs),
-    icon: ImageVector = Icons.Outlined.OpenInNew,
+    icon: ImageVector = Icons.AutoMirrored.Outlined.OpenInNew,
     link: String = ytdlpReference
 ) {
     val uriHandler = LocalUriHandler.current

--- a/app/src/main/java/com/junkfood/seal/ui/component/Dialogs.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/component/Dialogs.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.SignalCellularConnectedNoInternet4Bar
 import androidx.compose.material3.AlertDialog
@@ -59,7 +60,7 @@ fun HelpDialog(
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text(text = stringResource(id = R.string.how_does_it_work)) },
-        icon = { Icon(Icons.Outlined.HelpOutline, null) },
+        icon = { Icon(Icons.AutoMirrored.Outlined.HelpOutline, null) },
         text = { Text(text = text) },
         confirmButton = confirmButton,
         dismissButton = dismissButton,

--- a/app/src/main/java/com/junkfood/seal/ui/component/Dialogs.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/component/Dialogs.kt
@@ -273,7 +273,7 @@ fun SealDialogVariant(
     tonalElevation: Dp = AlertDialogDefaults.TonalElevation,
     properties: DialogProperties = DialogProperties()
 ) {
-    AlertDialog(
+    BasicAlertDialog(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         properties = properties

--- a/app/src/main/java/com/junkfood/seal/ui/component/DownloadQueueItem.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/component/DownloadQueueItem.kt
@@ -273,12 +273,13 @@ fun CustomCommandTaskItem(
                                 )
                             else
                                 CircularProgressIndicator(
+                                    progress = { animatedProgress },
                                     modifier = Modifier
                                         .padding(8.dp)
                                         .size(24.dp),
+                                    color = accentColor,
                                     strokeWidth = 5.dp,
-                                    progress = animatedProgress,
-                                    color = accentColor
+                                    trackColor = ProgressIndicatorDefaults.circularDeterminateTrackColor,
                                 )
                         }
 

--- a/app/src/main/java/com/junkfood/seal/ui/page/command/TaskLogPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/command/TaskLogPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedAssistChip
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -84,7 +85,7 @@ fun TaskLogPage(onNavigateBack: () -> Unit, taskHashCode: Int) {
                     .navigationBarsPadding(),
                 verticalArrangement = Arrangement.Center
             ) {
-                Divider(modifier = Modifier.fillMaxWidth())
+                HorizontalDivider(modifier = Modifier.fillMaxWidth())
                 Row(
                     Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionDialog.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
 import androidx.compose.material.icons.outlined.PlaylistAdd
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -53,7 +54,7 @@ fun PlaylistSelectionDialog(
         }
     }
     AlertDialog(onDismissRequest = { onDismissRequest() },
-        icon = { Icon(Icons.Outlined.PlaylistAdd, null) },
+        icon = { Icon(Icons.AutoMirrored.Outlined.PlaylistAdd, null) },
         title = { Text(stringResource(R.string.download_range_selection)) },
         text = {
             Column {

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionPage.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.PlaylistAdd
 import androidx.compose.material3.Checkbox
@@ -145,7 +146,7 @@ fun PlaylistSelectionPage(onNavigateBack: () -> Unit = {}) {
                     IconButton(modifier = Modifier.padding(end = 4.dp),
                         onClick = { showDialog = true }) {
                         Icon(
-                            imageVector = Icons.Outlined.PlaylistAdd,
+                            imageVector = Icons.AutoMirrored.Outlined.PlaylistAdd,
                             contentDescription = stringResource(
                                 R.string.download_range_selection
                             )

--- a/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/download/PlaylistSelectionPage.kt
@@ -15,10 +15,9 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
 import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material.icons.outlined.PlaylistAdd
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -117,7 +116,7 @@ fun PlaylistSelectionPage(onNavigateBack: () -> Unit = {}) {
                     .navigationBarsPadding(),
                 verticalArrangement = Arrangement.Center
             ) {
-                Divider(modifier = Modifier.fillMaxWidth())
+                HorizontalDivider(modifier = Modifier.fillMaxWidth())
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Row(
                         modifier = Modifier.selectable(selected = selectedItems.size == playlistCount && selectedItems.size != 0,

--- a/app/src/main/java/com/junkfood/seal/ui/page/downloadv2/DownloadPageV2.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/downloadv2/DownloadPageV2.kt
@@ -322,7 +322,7 @@ fun InputUrl(
                     .clip(MaterialTheme.shapes.large),
             )
             else LinearProgressIndicator(
-                progress = progressAnimationValue,
+                progress = { progressAnimationValue },
                 modifier = Modifier
                     .weight(0.75f)
                     .clip(MaterialTheme.shapes.large),
@@ -599,8 +599,8 @@ fun VideoCardV2(
                 modifier = Modifier.fillMaxWidth(),
             )
             else LinearProgressIndicator(
+                progress = { progressAnimationValue / 100f },
                 modifier = Modifier.fillMaxWidth(),
-                progress = progressAnimationValue / 100f,
             )
         }
     }

--- a/app/src/main/java/com/junkfood/seal/ui/page/downloadv2/FormatPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/downloadv2/FormatPage.kt
@@ -2,6 +2,8 @@ package com.junkfood.seal.ui.page.downloadv2
 
 import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -35,7 +37,6 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.Subtitles
-import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -73,6 +74,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.junkfood.seal.Downloader
@@ -108,9 +110,9 @@ import com.junkfood.seal.util.VIDEO_CLIP
 import com.junkfood.seal.util.VideoClip
 import com.junkfood.seal.util.VideoInfo
 import com.junkfood.seal.util.toHttpsUrl
+import kotlinx.coroutines.delay
 import kotlin.math.min
 import kotlin.math.roundToInt
-import kotlinx.coroutines.delay
 
 private const val TAG = "FormatPage"
 
@@ -882,7 +884,13 @@ private fun SubtitleSelectionDialog(
                     for ((code, formats) in suggestedSubtitlesFiltered) {
                         item(key = code) {
                             DialogCheckBoxItem(
-                                modifier = Modifier.animateItemPlacement(),
+                                modifier = Modifier.animateItem(
+                                    fadeInSpec = null, fadeOutSpec = null,
+                                    placementSpec = spring(
+                                        stiffness = Spring.StiffnessMediumLow,
+                                        visibilityThreshold = IntOffset.VisibilityThreshold
+                                    )
+                                ),
                                 checked = selectedSubtitles.contains(code),
                                 onClick = {
                                     if (selectedSubtitles.contains(code)) {
@@ -906,7 +914,14 @@ private fun SubtitleSelectionDialog(
                         for ((code, formats) in autoCaptionsFiltered) {
                             item(key = code) {
                                 DialogCheckBoxItem(
-                                    modifier = Modifier.animateItemPlacement(),
+                                    modifier = Modifier.animateItem(
+                                        fadeInSpec = null,
+                                        fadeOutSpec = null,
+                                        placementSpec = spring(
+                                            stiffness = Spring.StiffnessMediumLow,
+                                            visibilityThreshold = IntOffset.VisibilityThreshold
+                                        )
+                                    ),
                                     checked = selectedSubtitles.contains(code),
                                     onClick = {
                                         if (selectedSubtitles.contains(code)) {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/about/AboutPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/about/AboutPage.kt
@@ -1,13 +1,12 @@
 package com.junkfood.seal.ui.page.settings.about
 
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ContactSupport
 import androidx.compose.material.icons.outlined.AutoAwesome
-import androidx.compose.material.icons.outlined.ContactSupport
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.NewReleases
@@ -39,11 +38,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.UrlAnnotation
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import com.junkfood.seal.App
 import com.junkfood.seal.App.Companion.packageInfo
@@ -200,7 +201,6 @@ fun AboutPage(
     })
 }
 
-@OptIn(ExperimentalTextApi::class)
 @Composable
 @Preview
 fun AutoUpdateUnavailableDialog(onDismissRequest: () -> Unit = {}) {
@@ -213,22 +213,27 @@ fun AutoUpdateUnavailableDialog(onDismissRequest: () -> Unit = {}) {
     )
 
     val annotatedString = buildAnnotatedString {
-        append(text)
+        append(text.substring(0, text.indexOf(hyperLinkText)))
         val startIndex = text.indexOf(hyperLinkText)
         val endIndex = startIndex + hyperLinkText.length
-        addUrlAnnotation(
-            UrlAnnotation("https://github.com/JunkFood02/Seal/releases/latest"),
-            start = startIndex,
-            end = endIndex
-        )
-        addStyle(
-            SpanStyle(
-                color = MaterialTheme.colorScheme.tertiary,
-                textDecoration = TextDecoration.Underline,
-            ), start = startIndex,
-            end = endIndex
-        )
 
+        withLink(
+            LinkAnnotation.Clickable(
+                tag = "Link to the latest app release in GitHub",
+                styles = TextLinkStyles(
+                    SpanStyle(
+                        color = MaterialTheme.colorScheme.tertiary,
+                        textDecoration = TextDecoration.Underline,
+                    )
+                ),
+                linkInteractionListener = { _ ->
+                    uriHandler.openUri("https://github.com/JunkFood02/Seal/releases/latest")
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                }
+            )
+        ) {
+            append(text.substring(startIndex, endIndex))
+        }
     }
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -245,16 +250,11 @@ fun AutoUpdateUnavailableDialog(onDismissRequest: () -> Unit = {}) {
             )
         },
         text = {
-            ClickableText(
+            Text(
                 text = annotatedString,
-                onClick = { index ->
-                    annotatedString.getUrlAnnotations(index, index).firstOrNull()?.let {
-                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                        uriHandler.openUri(it.item.url)
-                    }
-                },
                 style = MaterialTheme.typography.bodyMedium.copy(MaterialTheme.colorScheme.onSurfaceVariant)
             )
-        })
+        }
+    )
 }
 

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/about/AboutPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/about/AboutPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ContactSupport
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.ContactSupport
 import androidx.compose.material.icons.outlined.Description
@@ -131,7 +132,7 @@ fun AboutPage(
                 PreferenceItem(
                     title = stringResource(R.string.github_issue),
                     description = stringResource(R.string.github_issue_desc),
-                    icon = Icons.Outlined.ContactSupport,
+                    icon = Icons.AutoMirrored.Outlined.ContactSupport,
                 ) { openUrl(githubIssueUrl) }
             }
             item {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/about/AboutPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/about/AboutPage.kt
@@ -41,9 +41,11 @@ import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.UrlAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withAnnotation
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import com.junkfood.seal.App
@@ -201,6 +203,7 @@ fun AboutPage(
     })
 }
 
+@OptIn(ExperimentalTextApi::class)
 @Composable
 @Preview
 fun AutoUpdateUnavailableDialog(onDismissRequest: () -> Unit = {}) {
@@ -214,8 +217,6 @@ fun AutoUpdateUnavailableDialog(onDismissRequest: () -> Unit = {}) {
 
     val annotatedString = buildAnnotatedString {
         append(text.substring(0, text.indexOf(hyperLinkText)))
-        val startIndex = text.indexOf(hyperLinkText)
-        val endIndex = startIndex + hyperLinkText.length
 
         withLink(
             LinkAnnotation.Clickable(
@@ -232,7 +233,7 @@ fun AutoUpdateUnavailableDialog(onDismissRequest: () -> Unit = {}) {
                 }
             )
         ) {
-            append(text.substring(startIndex, endIndex))
+            append(hyperLinkText)
         }
     }
     AlertDialog(

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/appearance/AppearancePreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/appearance/AppearancePreferences.kt
@@ -183,7 +183,8 @@ fun AppearancePreferences(
                     }
                 }
 
-                HorizontalPagerIndicator(pagerState = pagerState,
+                HorizontalPagerIndicator(
+                    pagerState = pagerState,
                     pageCount = pageCount,
                     modifier = Modifier
                         .clearAndSetSemantics { }

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/command/TemplateListPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/command/TemplateListPage.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.AssignmentReturn
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.AssignmentReturn
 import androidx.compose.material.icons.outlined.BookmarkAdd
@@ -157,7 +159,7 @@ fun TemplateListPage(onNavigateBack: () -> Unit, onNavigateToEditPage: (Int) -> 
                     showHelpDialog = true
                 }) {
                     Icon(
-                        imageVector = Icons.Outlined.HelpOutline,
+                        imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                         contentDescription = stringResource(
                             id = R.string.how_does_it_work
                         )
@@ -200,7 +202,7 @@ fun TemplateListPage(onNavigateBack: () -> Unit, onNavigateToEditPage: (Int) -> 
                             })
                             DropdownMenuItem(leadingIcon = {
                                 Icon(
-                                    Icons.Outlined.AssignmentReturn, null
+                                    Icons.AutoMirrored.Outlined.AssignmentReturn, null
                                 )
                             }, text = {
                                 Text(stringResource(R.string.import_from_clipboard))

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/format/DownloadFormatPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/format/DownloadFormatPreferences.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.ArtTrack
 import androidx.compose.material.icons.outlined.AudioFile
 import androidx.compose.material.icons.outlined.ContentCut
@@ -273,7 +274,7 @@ fun DownloadFormatPreferences(onNavigateBack: () -> Unit, navigateToSubtitlePage
                 }
                 item {
                     PreferenceSwitchWithDivider(title = stringResource(id = R.string.format_sorting),
-                        icon = Icons.Outlined.Sort,
+                        icon = Icons.AutoMirrored.Outlined.Sort,
                         description = stringResource(id = R.string.format_sorting_desc),
                         enabled = !isCustomCommandEnabled,
                         isChecked = isFormatSortingEnabled,

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/general/GeneralDownloadPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/general/GeneralDownloadPreferences.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.PlaylistAddCheck
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.Edit
@@ -378,7 +379,7 @@ fun GeneralDownloadPreferences(
                                 PLAYLIST, downloadPlaylist
                             )
                         },
-                        icon = Icons.Outlined.PlaylistAddCheck,
+                        icon = Icons.AutoMirrored.Outlined.PlaylistAddCheck,
                         enabled = !isCustomCommandEnabled,
                         description = stringResource(R.string.download_playlist_desc),
                         isChecked = downloadPlaylist

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/general/GeneralDownloadPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/general/GeneralDownloadPreferences.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
@@ -456,7 +457,7 @@ fun GeneralDownloadPreferences(
             title = { Text(text = stringResource(id = R.string.update)) },
             icon = { Icon(Icons.Outlined.SyncAlt, null) },
             text = {
-                LazyColumn() {
+                LazyColumn {
                     item {
                         Text(
                             text = stringResource(id = R.string.update_channel),
@@ -500,6 +501,7 @@ fun GeneralDownloadPreferences(
                     }
                     item {
                         var expanded by remember { mutableStateOf(false) }
+                        val type = MenuAnchorType.PrimaryNotEditable
 
                         ExposedDropdownMenuBox(
                             modifier = Modifier.padding(horizontal = 20.dp),
@@ -513,7 +515,7 @@ fun GeneralDownloadPreferences(
                                 readOnly = true,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .menuAnchor(),
+                                    .menuAnchor(type = type, enabled = true),
                                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                                 trailingIcon = {
                                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Cookie
 import androidx.compose.material.icons.outlined.Delete
@@ -176,7 +177,7 @@ fun CookieProfilePage(
                 var expanded by remember { mutableStateOf(false) }
                 IconButton(onClick = { showHelpDialog = true }) {
                     Icon(
-                        imageVector = Icons.Outlined.HelpOutline,
+                        imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                         contentDescription = stringResource(R.string.how_does_it_work)
                     )
                 }


### PR DESCRIPTION
This PR updates several icons to use their AutoMirrored counterparts for better right-to-left language support. It also updates all the deprecated UI components to use their new implementations.

`HorizontalPagerIndicator` still needs to be migrated, but Google hasn't updated it, so an own-implementation may be needed