### PR TITLE
Fix API level check for Android 13 (Tiramisu)

### DIFF
--- a/app/src/main/java/com/junkfood/seal/App.kt
+++ b/app/src/main/java/com/junkfood/seal/App.kt
@@ -76,7 +76,7 @@ class App : Application() {
         context = applicationContext
         packageInfo =
             packageManager.run {
-                if (Build.VERSION.SDK_INT >= 33)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                     getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
                 else getPackageInfo(packageName, 0)
             }

--- a/app/src/main/java/com/junkfood/seal/MainActivity.kt
+++ b/app/src/main/java/com/junkfood/seal/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (Build.VERSION.SDK_INT < 33) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             runBlocking { setLanguage(PreferenceUtil.getLocaleFromPreference()) }
         }
         enableEdgeToEdge()


### PR DESCRIPTION
- Replaced `Build.VERSION.SDK_INT >= 33` with `Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU` for better clarity and consistency.
- This ensures the code explicitly refers to Android 13 (Tiramisu) by its constant instead of using a hardcoded value.