### PR TITLE
Fix incorrect tag name in QuickDownloadActivity

### DIFF
--- a/app/src/main/java/com/junkfood/seal/QuickDownloadActivity.kt
+++ b/app/src/main/java/com/junkfood/seal/QuickDownloadActivity.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.koin.androidx.viewmodel.ext.android.getViewModel
 
-private const val TAG = "ShareActivity"
+private const val TAG = "QuickDownloadActivity"
 
 class QuickDownloadActivity : ComponentActivity() {
     private var sharedUrlCached: String = ""


### PR DESCRIPTION
- Corrected the tag name from `ShareActivity` to `QuickDownloadActivity`.
- This ensures the correct tag is used for logging purposes in the `QuickDownloadActivity` class.