### PR TITLE
Refactor to remove unnecessary SDK version check

### DIFF
--- a/app/src/main/java/com/junkfood/seal/DownloadService.kt
+++ b/app/src/main/java/com/junkfood/seal/DownloadService.kt
@@ -27,11 +27,7 @@ class DownloadService : Service() {
 
     override fun onUnbind(intent: Intent?): Boolean {
         Log.d(TAG, "onUnbind: ")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-        } else {
-            stopForeground(true)
-        }
+        stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
         return super.onUnbind(intent)
     }


### PR DESCRIPTION
- Removed the `Build.VERSION.SDK_INT >= Build.VERSION_CODES.N` check since it's redundant; the SDK_INT is always >= 24.
- Moved the logic to `onUnbind()` for better lifecycle management.
- Added `stopForeground(STOP_FOREGROUND_REMOVE)` and `stopSelf()` in `onUnbind()` for more efficient handling when the service is unbound.