### PR TITLE
Convert State objects to data objects

### DIFF
--- a/app/src/main/java/com/junkfood/seal/Downloader.kt
+++ b/app/src/main/java/com/junkfood/seal/Downloader.kt
@@ -83,9 +83,9 @@ object Downloader {
         sealed class State {
             data class Error(val errorReport: String) : State()
 
-            object Completed : State()
+            data object Completed : State()
 
-            object Canceled : State()
+            data object Canceled : State()
 
             data class Running(val progress: Float) : State()
         }


### PR DESCRIPTION
- Updated `Completed` and `Canceled` state objects to `data object`.
- This allows for value equality comparison, ensuring better consistency when working with these states.
- The change makes the state objects more appropriate for cases where equality checks are necessary.