### PR TITLE
Replace hardcoded SDK version with Build.VERSION_CODES.O

### DIFF
--- a/app/src/main/java/com/junkfood/seal/util/DateTimeUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DateTimeUtil.kt
@@ -12,7 +12,7 @@ private val SimpleDateFormat by lazy {
 }
 
 fun Long.toLocalizedString(locale: Locale = Locale.getDefault()): String {
-    return if (Build.VERSION.SDK_INT >= 26) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, locale)
             .format(Date.from(Instant.ofEpochMilli(this)))
     } else {


### PR DESCRIPTION
- Replaced the hardcoded SDK version `26` with `Build.VERSION_CODES.O` in the `toLocalizedString` function.
- This ensures the code is more readable and consistent by using the constant instead of the hardcoded version number.
- The functionality remains the same, checking for Android API level 26 (Oreo) and above when formatting dates.