### PR TITLE
Added multiple URL support from other apps like Newpipe

### DIFF
--- a/app/src/main/java/com/junkfood/seal/util/TextUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/TextUtil.kt
@@ -88,11 +88,12 @@ fun matchUrlFromClipboard(string: String, isMatchingMultiLink: Boolean = false):
     }
 }
 
-fun matchUrlFromSharedText(s: String): String {
-    findURLsFromString(s, true).joinToString(separator = "\n").run {
-        if (isEmpty()) ToastUtil.makeToast(R.string.share_fail_msg)
-        //            else makeToast(R.string.share_success_msg)
-        return this
+fun matchUrlsFromSharedText(s: String): List<String> {
+    return findURLsFromString(s, false).let {
+        if (it.isEmpty()) {
+            context.makeToast(R.string.share_fail_msg)
+        }
+        it
     }
 }
 


### PR DESCRIPTION
## Description

- There was an issue #1897, which mentioned that URLs are not being downloaded.
- After checking, it was found that when Newpipe shares the intent with the app, it shares the playlist as URLs joined with the `\n` operator, hence added support for this.