### PR TITLE
Share task log output as file

### DIFF
--- a/app/src/main/java/com/junkfood/seal/Downloader.kt
+++ b/app/src/main/java/com/junkfood/seal/Downloader.kt
@@ -1,6 +1,8 @@
 package com.junkfood.seal
 
 import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.annotation.CheckResult
 import androidx.compose.runtime.Composable
@@ -34,6 +36,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.File
 
 /** Singleton Downloader for state holder & perform downloads, used by `Activity` & `Service` */
 object Downloader {
@@ -111,6 +114,13 @@ object Downloader {
 
         fun onCopyLog(clipboardManager: ClipboardManager) {
             clipboardManager.setText(AnnotatedString(output))
+        }
+
+        fun onShareLogAsFile(activityContext: Context) {
+            val tempFile = File.createTempFile("seal_log_", ".txt", activityContext.cacheDir)
+            tempFile.writeText(output)
+            val shareIntent = FileUtil.createIntentForSharingFile(tempFile, "text/plain")
+            activityContext.startActivity(Intent.createChooser(shareIntent, "Share log as file via"))
         }
 
         fun onRestart() {

--- a/app/src/main/java/com/junkfood/seal/ui/page/command/TaskLogPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/command/TaskLogPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.RestartAlt
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.UnfoldMore
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Divider
@@ -41,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
@@ -95,6 +97,15 @@ fun TaskLogPage(onNavigateBack: () -> Unit, taskHashCode: Int) {
                             label = stringResource(id = R.string.copy_log),
                         ) {
                             onCopyLog(clipboardManager)
+                        }
+                        if (!(state is Downloader.CustomCommandTask.State.Running)) {
+                            val activityContext = LocalContext.current
+                            ButtonChip(
+                                icon = Icons.Outlined.Share,
+                                label = stringResource(id = R.string.share_log_as_file),
+                            ) {
+                                onShareLogAsFile(activityContext)
+                            }
                         }
                         if (state is Downloader.CustomCommandTask.State.Error)
                             ButtonChip(

--- a/app/src/main/java/com/junkfood/seal/util/FileUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/FileUtil.kt
@@ -82,6 +82,19 @@ object FileUtil {
             clipData = ClipData(null, arrayOf(mimeType), ClipData.Item(data))
         }
 
+    fun createIntentForSharingFile(file: File, mimeType: String): Intent? {
+        val uri = FileProvider.getUriForFile(
+            context,
+            context.getFileProvider(),
+            file
+        )
+        return Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
     fun Context.getFileProvider() = "$packageName.provider"
 
     fun String.getFileSize(): Long =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,7 @@
     <string name="subtitle_language">Subtitle languages</string>
     <string name="subtitle_desc">Languages, embed subtitles, auto captions</string>
     <string name="copy_log">Copy log</string>
+    <string name="share_log_as_file">Share as file</string>
     <string name="clear">Clear</string>
     <string name="edit_shortcuts">Edit shortcuts</string>
     <string name="add">Add</string>


### PR DESCRIPTION
Since the clipboard is not ideal for transferring large logs,  I added a 'share as file' option.