### PR TITLE
Fix the Youtube Auto Local Language Download Bug for Automatic format.

### DIFF
--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -447,6 +447,7 @@ object DownloadUtil {
                     }
                 } else {
                     applyFormatSorter(this, toFormatSorter())
+                    addOption("--audio-multistreams")
                 }
                 if (downloadSubtitle) {
                     if (autoSubtitle) {
@@ -601,6 +602,7 @@ object DownloadUtil {
                     }
                 } else {
                     applyFormatSorter(preferences, toAudioFormatSorter())
+                    addOption("--audio-multistreams")
                 }
 
                 if (embedMetadata) {


### PR DESCRIPTION
The issue is that when "Format: automatic" is selected, yt-dlp picks the "best" audio track. Due to YouTube's multi-language audio feature and the user's VPN usage, yt-dlp (or YouTube) defaults to a dubbed audio track instead of the original English one.

To fix this, I've updated DownloadUtil.kt to include the --audio-multistreams option when the download format is set to "Automatic" (which corresponds to an empty formatIdString). This forces yt-dlp to download and merge all available audio streams into the output file. This ensures that the original audio track is included, allowing the user to select the correct language in their media player.

I applied this fix to both:
- Audio Downloads (addOptionsForAudioDownloads): This directly addresses the user's report ("Set Audio").
- Video Downloads (addOptionsForVideoDownloads): To ensure consistency and prevent the same issue when downloading videos.