### PR TITLE
fix(ui): hide software keyboard when dismissing TaskCreatorDialogContent

### DIFF
--- a/app/src/main/java/com/junkfood/seal/ui/page/command/TaskListPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/command/TaskListPage.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -95,6 +96,8 @@ fun TaskListPage(onNavigateBack: () -> Unit, onNavigateToDetail: (Int) -> Unit) 
             skipHalfExpanded = true,
             initialValue = ModalBottomSheetValue.Hidden,
         )
+    val keyboardController = LocalSoftwareKeyboardController.current
+
 
     Scaffold(
         modifier = Modifier.fillMaxSize().nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -187,6 +190,8 @@ fun TaskListPage(onNavigateBack: () -> Unit, onNavigateToDetail: (Int) -> Unit) 
                 LaunchedEffect(sheetState.targetValue) {
                     if (sheetState.targetValue == ModalBottomSheetValue.Expanded)
                         url = matchUrlFromString(clipboardManager.getText()?.text.toString(), true)
+                    if (sheetState.targetValue == ModalBottomSheetValue.Hidden)
+                        keyboardController?.hide()
                 }
 
                 Column(Modifier.fillMaxWidth()) {


### PR DESCRIPTION
### Description
When clicking outside the `TaskCreatorDialogContent` to dismiss it, the software keyboard remains visible on the screen. This PR adds explicit keyboard hiding logic to the `onDismissRequest` callback to ensure a clean UI transition.

### Related Issue
Closes #2463

### Testing
- [x] Verified on Android 15 (API 35).
- [x] Keyboard hides immediately when clicking the dimmed background.