### PR TITLE
Feat/cookie netscape import

### DIFF
--- a/app/src/main/java/com/junkfood/seal/database/VideoInfoDao.kt
+++ b/app/src/main/java/com/junkfood/seal/database/VideoInfoDao.kt
@@ -54,6 +54,9 @@ interface VideoInfoDao {
 
     @Query("select * from CookieProfile") fun getCookieProfileFlow(): Flow<List<CookieProfile>>
 
+    @Query("select * from CookieProfile order by id asc")
+    suspend fun getCookieProfileList(): List<CookieProfile>
+
     @Insert suspend fun insertTemplate(template: CommandTemplate): Long
 
     @Insert @Transaction suspend fun importTemplates(templateList: List<CommandTemplate>)

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieParser.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieParser.kt
@@ -49,6 +49,9 @@ object CookieParser {
         cookies.values.toList()
     }
 
+    fun groupCookiesByDomain(cookies: List<Cookie>): Map<String, List<Cookie>> =
+        cookies.groupBy { it.domain.normalizedCookieDomain() }
+
     private fun String.toNetscapeBoolean(lineIndex: Int): Boolean =
         when (uppercase()) {
             "TRUE" -> true
@@ -56,6 +59,12 @@ object CookieParser {
             else ->
                 throw IllegalArgumentException("Invalid cookie boolean at line ${lineIndex + 1}")
         }
+
+    private fun String.normalizedCookieDomain(): String {
+        val normalized = trim().trimStart('.').lowercase()
+        require(normalized.isNotEmpty()) { "Invalid cookie domain" }
+        return normalized
+    }
 
     private data class CookieKey(val domain: String, val path: String, val name: String)
 }

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieParser.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieParser.kt
@@ -1,0 +1,61 @@
+package com.junkfood.seal.ui.page.settings.network
+
+object CookieParser {
+    private const val HTTP_ONLY_PREFIX = "#HttpOnly_"
+    private const val FIELD_COUNT = 7
+
+    fun parseNetscapeCookies(content: String): Result<List<Cookie>> = runCatching {
+        val cookies = linkedMapOf<CookieKey, Cookie>()
+        content.lineSequence().forEachIndexed { index, rawLine ->
+            val line = rawLine.trimEnd('\r')
+            if (line.isBlank()) return@forEachIndexed
+
+            val cookieLine =
+                when {
+                    line.startsWith(HTTP_ONLY_PREFIX) -> line.removePrefix(HTTP_ONLY_PREFIX)
+                    line.startsWith("#") -> return@forEachIndexed
+                    else -> line
+                }
+
+            val fields = cookieLine.split('\t')
+            if (fields.size != FIELD_COUNT) {
+                throw IllegalArgumentException("Invalid cookie format at line ${index + 1}")
+            }
+
+            val domain = fields[0]
+            val includeSubdomains = fields[1].toNetscapeBoolean(index)
+            val path = fields[2]
+            val secure = fields[3].toNetscapeBoolean(index)
+            val expiry =
+                fields[4].toLongOrNull()
+                    ?: throw IllegalArgumentException("Invalid cookie expiry at line ${index + 1}")
+            val name = fields[5]
+            val value = fields[6]
+
+            val cookie =
+                Cookie(
+                    domain = domain,
+                    name = name,
+                    value = value,
+                    includeSubdomains = includeSubdomains,
+                    path = path,
+                    secure = secure,
+                    expiry = expiry,
+                )
+            cookies[CookieKey(domain = domain, path = path, name = name)] = cookie
+        }
+
+        if (cookies.isEmpty()) throw IllegalArgumentException("No cookies found")
+        cookies.values.toList()
+    }
+
+    private fun String.toNetscapeBoolean(lineIndex: Int): Boolean =
+        when (uppercase()) {
+            "TRUE" -> true
+            "FALSE" -> false
+            else ->
+                throw IllegalArgumentException("Invalid cookie boolean at line ${lineIndex + 1}")
+        }
+
+    private data class CookieKey(val domain: String, val path: String, val name: String)
+}

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.Cookie
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DeleteForever
@@ -32,6 +33,7 @@ import androidx.compose.material.icons.outlined.FileCopy
 import androidx.compose.material.icons.outlined.GeneratingTokens
 import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
@@ -95,6 +97,7 @@ import com.junkfood.seal.util.FileUtil
 import com.junkfood.seal.util.FileUtil.getCookiesFile
 import com.junkfood.seal.util.PreferenceUtil.getBoolean
 import com.junkfood.seal.util.PreferenceUtil.updateBoolean
+import com.junkfood.seal.util.ToastUtil
 import com.junkfood.seal.util.USER_AGENT
 import com.junkfood.seal.util.matchUrlFromClipboard
 import kotlinx.coroutines.Dispatchers
@@ -131,6 +134,34 @@ fun CookieProfilePage(
 
     var showEditDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var importPreview by remember { mutableStateOf<NetscapeCookieImportPreview?>(null) }
+
+    val clipboardSource = stringResource(R.string.clipboard)
+    val fileSource = stringResource(R.string.file)
+    val clipboardProfileUrl = stringResource(R.string.imported_cookies_from_clipboard)
+    val fileProfileUrl = stringResource(R.string.imported_cookies_from_file)
+
+    fun previewNetscapeCookieImport(source: String, profileUrl: String, content: String) {
+        scope.launch(Dispatchers.IO) {
+            CookieParser.parseNetscapeCookies(content)
+                .onSuccess { parsedCookies ->
+                    withContext(Dispatchers.Main) {
+                        importPreview =
+                            NetscapeCookieImportPreview(
+                                source = source,
+                                profileUrl = profileUrl,
+                                cookies = parsedCookies,
+                                importedCount = parsedCookies.size,
+                            )
+                    }
+                }
+                .onFailure {
+                    withContext(Dispatchers.Main) {
+                        ToastUtil.makeToast(context.getString(R.string.import_cookies_failed))
+                    }
+                }
+        }
+    }
 
     DisposableEffect(shouldUpdateCookies) {
         scope.launch(Dispatchers.IO) {
@@ -150,6 +181,28 @@ fun CookieProfilePage(
                 scope.launch(Dispatchers.IO) {
                     context.contentResolver.openOutputStream(uri)?.use {
                         it.write(cookieList.toCookiesFileContent().toByteArray())
+                    }
+                }
+            }
+        }
+
+    val importLauncher =
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri ->
+            uri?.let {
+                scope.launch(Dispatchers.IO) {
+                    val content =
+                        runCatching {
+                                context.contentResolver.openInputStream(uri)?.use { input ->
+                                    input.bufferedReader(Charsets.UTF_8).readText()
+                                }
+                            }
+                            .getOrNull()
+                    withContext(Dispatchers.Main) {
+                        if (content.isNullOrBlank()) {
+                            ToastUtil.makeToast(context.getString(R.string.import_cookies_failed))
+                        } else {
+                            previewNetscapeCookieImport(fileSource, fileProfileUrl, content)
+                        }
                     }
                 }
             }
@@ -199,6 +252,33 @@ fun CookieProfilePage(
                             onClick = ::toggleUserAgent,
                         )
                         DropdownMenuItem(
+                            leadingIcon = { Icon(Icons.Outlined.ContentPaste, null) },
+                            text = {
+                                Text(stringResource(id = R.string.import_cookies_from_clipboard))
+                            },
+                            onClick = {
+                                expanded = false
+                                clipboardManager.getText()?.text?.let { content ->
+                                    previewNetscapeCookieImport(
+                                        source = clipboardSource,
+                                        profileUrl = clipboardProfileUrl,
+                                        content = content,
+                                    )
+                                }
+                                    ?: ToastUtil.makeToast(
+                                        context.getString(R.string.import_cookies_failed)
+                                    )
+                            },
+                        )
+                        DropdownMenuItem(
+                            leadingIcon = { Icon(Icons.Outlined.Restore, null) },
+                            text = { Text(stringResource(id = R.string.import_cookies_from_file)) },
+                            onClick = {
+                                expanded = false
+                                importLauncher.launch("text/plain")
+                            },
+                        )
+                        DropdownMenuItem(
                             leadingIcon = { Icon(Icons.Outlined.FileCopy, null) },
                             text = { Text(stringResource(id = R.string.export_to_file)) },
                             enabled = cookieList.isNotEmpty(),
@@ -235,7 +315,7 @@ fun CookieProfilePage(
                             isCookieEnabled = false
                             COOKIES.updateBoolean(false)
                         } else if (
-                            (cookies.isEmpty() || !cookieManager.hasCookies()) && !isCookieEnabled
+                            cookies.isEmpty() && !cookieManager.hasCookies() && !isCookieEnabled
                         ) {
                             showHelpDialog = true
                         } else {
@@ -316,6 +396,71 @@ fun CookieProfilePage(
                 .invokeOnCompletion { shouldUpdateCookies = true }
         }
     }
+    importPreview?.let { preview ->
+        ImportNetscapeCookieConfirmationDialog(
+            preview = preview,
+            onDismissRequest = { importPreview = null },
+            onConfirm = {
+                scope.launch(Dispatchers.IO) {
+                    val result =
+                        cookiesViewModel.importNetscapeCookieProfile(
+                            url = preview.profileUrl,
+                            cookies = preview.cookies,
+                        )
+                    withContext(Dispatchers.Main) {
+                        result
+                            .onSuccess {
+                                ToastUtil.makeToast(
+                                    context.getString(R.string.cookies_imported, it.importedCount)
+                                )
+                                importPreview = null
+                                shouldUpdateCookies = true
+                            }
+                            .onFailure {
+                                ToastUtil.makeToast(
+                                    context.getString(R.string.import_cookies_failed)
+                                )
+                            }
+                    }
+                }
+            },
+        )
+    }
+}
+
+private data class NetscapeCookieImportPreview(
+    val source: String,
+    val profileUrl: String,
+    val cookies: List<Cookie>,
+    val importedCount: Int,
+)
+
+@Composable
+private fun ImportNetscapeCookieConfirmationDialog(
+    preview: NetscapeCookieImportPreview,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        icon = { Icon(Icons.Outlined.Cookie, null) },
+        title = { Text(stringResource(R.string.import_cookies)) },
+        text = {
+            Text(
+                text =
+                    stringResource(
+                        R.string.import_cookies_confirmation_msg,
+                        preview.importedCount,
+                        preview.source,
+                    ),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
+        dismissButton = { DismissButton { onDismissRequest() } },
+        confirmButton = {
+            ConfirmButton(text = stringResource(R.string.import_backup)) { onConfirm() }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -121,7 +121,6 @@ fun CookieProfilePage(
     val hapticFeedback = LocalHapticFeedback.current
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
-    val state by cookiesViewModel.stateFlow.collectAsStateWithLifecycle()
     var showClearCookieDialog by remember { mutableStateOf(false) }
     var isCookieEnabled by remember { mutableStateOf(COOKIES.getBoolean()) }
     val cookieManager = CookieManager.getInstance()
@@ -152,6 +151,7 @@ fun CookieProfilePage(
                                 profileUrl = profileUrl,
                                 cookies = parsedCookies,
                                 importedCount = parsedCookies.size,
+                                profileCount = CookieParser.groupCookiesByDomain(parsedCookies).size,
                             )
                     }
                 }
@@ -252,33 +252,6 @@ fun CookieProfilePage(
                             onClick = ::toggleUserAgent,
                         )
                         DropdownMenuItem(
-                            leadingIcon = { Icon(Icons.Outlined.ContentPaste, null) },
-                            text = {
-                                Text(stringResource(id = R.string.import_cookies_from_clipboard))
-                            },
-                            onClick = {
-                                expanded = false
-                                clipboardManager.getText()?.text?.let { content ->
-                                    previewNetscapeCookieImport(
-                                        source = clipboardSource,
-                                        profileUrl = clipboardProfileUrl,
-                                        content = content,
-                                    )
-                                }
-                                    ?: ToastUtil.makeToast(
-                                        context.getString(R.string.import_cookies_failed)
-                                    )
-                            },
-                        )
-                        DropdownMenuItem(
-                            leadingIcon = { Icon(Icons.Outlined.Restore, null) },
-                            text = { Text(stringResource(id = R.string.import_cookies_from_file)) },
-                            onClick = {
-                                expanded = false
-                                importLauncher.launch("text/plain")
-                            },
-                        )
-                        DropdownMenuItem(
                             leadingIcon = { Icon(Icons.Outlined.FileCopy, null) },
                             text = { Text(stringResource(id = R.string.export_to_file)) },
                             enabled = cookieList.isNotEmpty(),
@@ -353,6 +326,28 @@ fun CookieProfilePage(
                 }
             }
             item {
+                PreferenceItemVariant(
+                    title = stringResource(id = R.string.import_cookies_from_clipboard),
+                    icon = Icons.Outlined.ContentPaste,
+                ) {
+                    clipboardManager.getText()?.text?.let { content ->
+                        previewNetscapeCookieImport(
+                            source = clipboardSource,
+                            profileUrl = clipboardProfileUrl,
+                            content = content,
+                        )
+                    } ?: ToastUtil.makeToast(context.getString(R.string.import_cookies_failed))
+                }
+            }
+            item {
+                PreferenceItemVariant(
+                    title = stringResource(id = R.string.import_cookies_from_file),
+                    icon = Icons.Outlined.Restore,
+                ) {
+                    importLauncher.launch("text/plain")
+                }
+            }
+            item {
                 androidx.compose.material3.HorizontalDivider()
                 val cookiesCount = cookieList.size
                 val siteCount = cookieList.distinctBy { it.domain }.size
@@ -400,18 +395,22 @@ fun CookieProfilePage(
         ImportNetscapeCookieConfirmationDialog(
             preview = preview,
             onDismissRequest = { importPreview = null },
-            onConfirm = {
+            onConfirm = { profileUrl ->
                 scope.launch(Dispatchers.IO) {
                     val result =
                         cookiesViewModel.importNetscapeCookieProfile(
-                            url = preview.profileUrl,
+                            url = profileUrl,
                             cookies = preview.cookies,
                         )
                     withContext(Dispatchers.Main) {
                         result
                             .onSuccess {
                                 ToastUtil.makeToast(
-                                    context.getString(R.string.cookies_imported, it.importedCount)
+                                    context.getString(
+                                        R.string.cookies_imported,
+                                        it.importedCount,
+                                        it.profileCount,
+                                    )
                                 )
                                 importPreview = null
                                 shouldUpdateCookies = true
@@ -433,32 +432,50 @@ private data class NetscapeCookieImportPreview(
     val profileUrl: String,
     val cookies: List<Cookie>,
     val importedCount: Int,
+    val profileCount: Int,
 )
 
 @Composable
 private fun ImportNetscapeCookieConfirmationDialog(
     preview: NetscapeCookieImportPreview,
     onDismissRequest: () -> Unit,
-    onConfirm: () -> Unit,
+    onConfirm: (String) -> Unit,
 ) {
+    var profileUrl by remember(preview) { mutableStateOf(preview.profileUrl) }
     AlertDialog(
         onDismissRequest = onDismissRequest,
         icon = { Icon(Icons.Outlined.Cookie, null) },
         title = { Text(stringResource(R.string.import_cookies)) },
         text = {
-            Text(
-                text =
-                    stringResource(
-                        R.string.import_cookies_confirmation_msg,
-                        preview.importedCount,
-                        preview.source,
-                    ),
-                style = MaterialTheme.typography.bodyLarge,
-            )
+            Column {
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
+                    value = profileUrl,
+                    label = { Text(stringResource(R.string.cookie_profile_label)) },
+                    onValueChange = { profileUrl = it },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                )
+                Text(
+                    text =
+                        stringResource(
+                            R.string.import_cookies_confirmation_msg,
+                            preview.importedCount,
+                            preview.source,
+                            preview.profileCount,
+                        ),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
         },
         dismissButton = { DismissButton { onDismissRequest() } },
         confirmButton = {
-            ConfirmButton(text = stringResource(R.string.import_backup)) { onConfirm() }
+            ConfirmButton(
+                enabled = profileUrl.isNotBlank(),
+                text = stringResource(R.string.import_backup),
+            ) {
+                onConfirm(profileUrl.trim())
+            }
         },
     )
 }

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookiesViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookiesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.junkfood.seal.database.objects.CookieProfile
 import com.junkfood.seal.util.DatabaseUtil
+import com.junkfood.seal.util.DownloadUtil.toCookiesFileContent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,6 +20,8 @@ class CookiesViewModel : ViewModel() {
         val editingCookieProfile: CookieProfile =
             CookieProfile(id = NEW_PROFILE_ID, url = "", content = "")
     )
+
+    data class CookieImportResult(val importedCount: Int)
 
     val cookiesFlow = DatabaseUtil.getCookiesFlow()
 
@@ -65,5 +68,23 @@ class CookiesViewModel : ViewModel() {
                 DatabaseUtil.updateCookieProfile(profile)
             }
         }
+    }
+
+    suspend fun importNetscapeCookieProfile(
+        url: String,
+        content: String,
+    ): Result<CookieImportResult> =
+        CookieParser.parseNetscapeCookies(content).mapCatching { cookies ->
+            importNetscapeCookieProfile(url = url, cookies = cookies).getOrThrow()
+        }
+
+    suspend fun importNetscapeCookieProfile(
+        url: String,
+        cookies: List<Cookie>,
+    ): Result<CookieImportResult> = runCatching {
+        DatabaseUtil.insertCookieProfile(
+            CookieProfile(id = NEW_PROFILE_ID, url = url, content = cookies.toCookiesFileContent())
+        )
+        CookieImportResult(importedCount = cookies.size)
     }
 }

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookiesViewModel.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookiesViewModel.kt
@@ -21,7 +21,7 @@ class CookiesViewModel : ViewModel() {
             CookieProfile(id = NEW_PROFILE_ID, url = "", content = "")
     )
 
-    data class CookieImportResult(val importedCount: Int)
+    data class CookieImportResult(val importedCount: Int, val profileCount: Int)
 
     val cookiesFlow = DatabaseUtil.getCookiesFlow()
 
@@ -82,9 +82,16 @@ class CookiesViewModel : ViewModel() {
         url: String,
         cookies: List<Cookie>,
     ): Result<CookieImportResult> = runCatching {
-        DatabaseUtil.insertCookieProfile(
-            CookieProfile(id = NEW_PROFILE_ID, url = url, content = cookies.toCookiesFileContent())
-        )
-        CookieImportResult(importedCount = cookies.size)
+        val groupedCookies = CookieParser.groupCookiesByDomain(cookies)
+        groupedCookies.forEach { (domain, domainCookies) ->
+            DatabaseUtil.insertCookieProfile(
+                CookieProfile(
+                    id = NEW_PROFILE_ID,
+                    url = if (groupedCookies.size == 1) url else domain,
+                    content = domainCookies.toCookiesFileContent(),
+                )
+            )
+        }
+        CookieImportResult(importedCount = cookies.size, profileCount = groupedCookies.size)
     }
 }

--- a/app/src/main/java/com/junkfood/seal/util/DatabaseUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DatabaseUtil.kt
@@ -41,6 +41,8 @@ object DatabaseUtil {
 
     fun getCookiesFlow() = dao.getCookieProfileFlow()
 
+    suspend fun getCookieProfileList() = dao.getCookieProfileList()
+
     fun getShortcuts() = dao.getOptionShortcuts()
 
     suspend fun deleteShortcut(shortcut: OptionShortcut) = dao.deleteShortcut(shortcut)

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -20,8 +20,10 @@ import com.junkfood.seal.Downloader.onTaskStarted
 import com.junkfood.seal.Downloader.toNotificationId
 import com.junkfood.seal.R
 import com.junkfood.seal.database.objects.CommandTemplate
+import com.junkfood.seal.database.objects.CookieProfile
 import com.junkfood.seal.database.objects.DownloadedVideoInfo
 import com.junkfood.seal.ui.page.settings.network.Cookie
+import com.junkfood.seal.ui.page.settings.network.CookieParser
 import com.junkfood.seal.util.FileUtil.getArchiveFile
 import com.junkfood.seal.util.FileUtil.getConfigFile
 import com.junkfood.seal.util.FileUtil.getCookiesFile
@@ -38,11 +40,11 @@ import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLException
 import com.yausername.youtubedl_android.YoutubeDLRequest
 import com.yausername.youtubedl_android.YoutubeDLResponse
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import java.util.Locale
 
 object DownloadUtil {
 
@@ -372,7 +374,7 @@ object DownloadUtil {
         this.addOption("--download-archive", context.getArchiveFile().absolutePath)
 
     @CheckResult
-    fun getCookieListFromDatabase(): Result<List<Cookie>> = runCatching {
+    private fun getWebViewCookieListFromDatabase(): Result<List<Cookie>> = runCatching {
         CookieManager.getInstance().run {
             if (!hasCookies()) throw Exception("There is no cookies in the database!")
             flush()
@@ -421,14 +423,50 @@ object DownloadUtil {
             }
     }
 
+    private fun Cookie.toRuntimeCookieKey(): RuntimeCookieKey =
+        RuntimeCookieKey(domain = domain, path = path, name = name)
+
+    fun mergeRuntimeCookies(
+        webViewCookies: List<Cookie>,
+        importedCookies: List<Cookie>,
+    ): List<Cookie> =
+        linkedMapOf<RuntimeCookieKey, Cookie>()
+            .apply {
+                webViewCookies.forEach { this[it.toRuntimeCookieKey()] = it }
+                importedCookies.forEach { this[it.toRuntimeCookieKey()] = it }
+            }
+            .values
+            .toList()
+
+    private fun List<CookieProfile>.parseImportedCookies(): Result<List<Cookie>> = runCatching {
+        filter { it.content.isNotBlank() }
+            .flatMap { profile -> CookieParser.parseNetscapeCookies(profile.content).getOrThrow() }
+    }
+
+    suspend fun getCookieListFromDatabase(): Result<List<Cookie>> {
+        val importedCookiesResult = DatabaseUtil.getCookieProfileList().parseImportedCookies()
+        val webViewCookiesResult = getWebViewCookieListFromDatabase()
+
+        return importedCookiesResult.mapCatching { importedCookies ->
+            val webViewCookies =
+                webViewCookiesResult.getOrElse {
+                    if (importedCookies.isEmpty()) throw it
+                    emptyList()
+                }
+            mergeRuntimeCookies(webViewCookies = webViewCookies, importedCookies = importedCookies)
+        }
+    }
+
     fun List<Cookie>.toCookiesFileContent(): String =
         this.fold(StringBuilder(COOKIE_HEADER)) { acc, cookie ->
                 acc.append(cookie.toNetscapeCookieString()).append("\n")
             }
             .toString()
 
-    fun getCookiesContentFromDatabase(): Result<String> =
+    suspend fun getCookiesContentFromDatabase(): Result<String> =
         getCookieListFromDatabase().mapCatching { it.toCookiesFileContent() }
+
+    private data class RuntimeCookieKey(val domain: String, val path: String, val name: String)
 
     private fun YoutubeDLRequest.enableAria2c(): YoutubeDLRequest =
         this.addOption("--downloader", "libaria2c.so")
@@ -531,11 +569,12 @@ object DownloadUtil {
                     7 -> "+res"
                     else -> ""
                 }
-            val sorter = if (videoFormat == FORMAT_COMPATIBILITY) {
-                connectWithDelimiter(format, res, delimiter = ",")
-            } else {
-                connectWithDelimiter(res, format, delimiter = ",")
-            }
+            val sorter =
+                if (videoFormat == FORMAT_COMPATIBILITY) {
+                    connectWithDelimiter(format, res, delimiter = ",")
+                } else {
+                    connectWithDelimiter(res, format, delimiter = ",")
+                }
             return@run sorter
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,14 @@
     <string name="cookies">Cookies</string>
     <string name="cookies_desc">Use Netscape formatted cookies for downloads</string>
     <string name="cookies_file_name" translatable="false">cookies.txt</string>
+    <string name="import_cookies">Import cookies</string>
+    <string name="import_cookies_from_clipboard">Import cookies from clipboard</string>
+    <string name="import_cookies_from_file">Import cookies from file</string>
+    <string name="import_cookies_confirmation_msg">Import %1$d cookie(s) from %2$s? Cookie names, values, and raw content are hidden for safety.</string>
+    <string name="cookies_imported">Imported %1$d cookie(s)</string>
+    <string name="import_cookies_failed">Could not import cookies</string>
+    <string name="imported_cookies_from_clipboard">Imported cookies from clipboard</string>
+    <string name="imported_cookies_from_file">Imported cookies from file</string>
     <string name="clear_temp_files">Clear temporary files</string>
     <string name="clear_temp_files_desc">Delete all temporary files from the temporary directory</string>
     <string name="clear_temp_files_count">Deleted %1$d temporary file(s)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,11 +189,12 @@
     <string name="import_cookies">Import cookies</string>
     <string name="import_cookies_from_clipboard">Import cookies from clipboard</string>
     <string name="import_cookies_from_file">Import cookies from file</string>
-    <string name="import_cookies_confirmation_msg">Import %1$d cookie(s) from %2$s? Cookie names, values, and raw content are hidden for safety.</string>
-    <string name="cookies_imported">Imported %1$d cookie(s)</string>
+    <string name="import_cookies_confirmation_msg">Import %1$d cookie(s) from %2$s into %3$d profile(s)? Cookie names, values, and raw content are hidden for safety.</string>
+    <string name="cookies_imported">Imported %1$d cookie(s) into %2$d profile(s)</string>
     <string name="import_cookies_failed">Could not import cookies</string>
     <string name="imported_cookies_from_clipboard">Imported cookies from clipboard</string>
     <string name="imported_cookies_from_file">Imported cookies from file</string>
+    <string name="cookie_profile_label">Saved URL or label</string>
     <string name="clear_temp_files">Clear temporary files</string>
     <string name="clear_temp_files_desc">Delete all temporary files from the temporary directory</string>
     <string name="clear_temp_files_count">Deleted %1$d temporary file(s)</string>

--- a/app/src/test/java/com/junkfood/seal/ui/page/settings/network/CookieParserTest.kt
+++ b/app/src/test/java/com/junkfood/seal/ui/page/settings/network/CookieParserTest.kt
@@ -1,0 +1,141 @@
+package com.junkfood.seal.ui.page.settings.network
+
+import com.junkfood.seal.util.DownloadUtil.mergeRuntimeCookies
+import com.junkfood.seal.util.DownloadUtil.toCookiesFileContent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CookieParserTest {
+    @Test
+    fun parseNetscapeCookies_acceptsHeaderAndCookieRow() {
+        val content =
+            "# Netscape HTTP Cookie File\n" +
+                "example.com\tFALSE\t/\tTRUE\t1717000000\tsession\tabc123\n"
+
+        val cookies = CookieParser.parseNetscapeCookies(content).getOrThrow()
+
+        assertEquals(1, cookies.size)
+        assertEquals(
+            Cookie(
+                domain = "example.com",
+                name = "session",
+                value = "abc123",
+                includeSubdomains = false,
+                path = "/",
+                secure = true,
+                expiry = 1717000000L,
+            ),
+            cookies.first(),
+        )
+    }
+
+    @Test
+    fun parseNetscapeCookies_ignoresBlankAndCommentLines() {
+        val content =
+            "\n" +
+                "# A regular comment\n" +
+                "example.com\tFALSE\t/\tTRUE\t1717000000\tsession\tabc123\n" +
+                "example.org\tTRUE\t/account\tFALSE\t0\tauth\txyz\n"
+
+        val cookies = CookieParser.parseNetscapeCookies(content).getOrThrow()
+
+        assertEquals(2, cookies.size)
+        assertEquals("example.com", cookies[0].domain)
+        assertEquals("example.org", cookies[1].domain)
+    }
+
+    @Test
+    fun parseNetscapeCookies_keepsHttpOnlyCookieRows() {
+        val content = "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t0\tsession\tsecret\n"
+
+        val cookie = CookieParser.parseNetscapeCookies(content).getOrThrow().single()
+
+        assertEquals(".example.com", cookie.domain)
+        assertEquals("session", cookie.name)
+        assertEquals("secret", cookie.value)
+    }
+
+    @Test
+    fun parseNetscapeCookies_acceptsMixedCaseBooleans() {
+        val content = "example.com\ttrue\t/\tFalse\t0\tsession\tabc123\n"
+
+        val cookie = CookieParser.parseNetscapeCookies(content).getOrThrow().single()
+
+        assertTrue(cookie.includeSubdomains)
+        assertEquals(false, cookie.secure)
+    }
+
+    @Test
+    fun parseNetscapeCookies_usesLastDuplicateCookieTuple() {
+        val content =
+            "example.com\tFALSE\t/\tTRUE\t1\tsession\told\n" +
+                "example.com\tFALSE\t/\tTRUE\t2\tsession\tnew\n"
+
+        val cookie = CookieParser.parseNetscapeCookies(content).getOrThrow().single()
+
+        assertEquals("new", cookie.value)
+        assertEquals(2L, cookie.expiry)
+    }
+
+    @Test
+    fun parseNetscapeCookies_rejectsRowsWithoutSevenTabSeparatedFields() {
+        val content = "example.com FALSE / TRUE 0 session abc123\n"
+
+        val result = CookieParser.parseNetscapeCookies(content)
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun parseNetscapeCookies_rejectsInvalidExpiry() {
+        val content = "example.com\tFALSE\t/\tTRUE\tnot-a-number\tsession\tabc123\n"
+
+        val result = CookieParser.parseNetscapeCookies(content)
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun parseNetscapeCookies_roundTripsSerializedCookies() {
+        val input =
+            "# Netscape HTTP Cookie File\n" +
+                "example.com\tFALSE\t/\tTRUE\t1717000000\tsession\tabc123\n" +
+                "#HttpOnly_.example.org\tTRUE\t/account\tFALSE\t0\tauth\txyz\n"
+
+        val parsed = CookieParser.parseNetscapeCookies(input).getOrThrow()
+        val reparsed = CookieParser.parseNetscapeCookies(parsed.toCookiesFileContent()).getOrThrow()
+
+        assertEquals(parsed, reparsed)
+    }
+
+    @Test
+    fun mergeRuntimeCookies_keepsImportedCookiesWhenWebViewIsEmpty() {
+        val importedCookie = Cookie(domain = "example.com", name = "session", value = "imported")
+
+        val cookies =
+            mergeRuntimeCookies(
+                webViewCookies = emptyList(),
+                importedCookies = listOf(importedCookie),
+            )
+
+        assertEquals(listOf(importedCookie), cookies)
+    }
+
+    @Test
+    fun mergeRuntimeCookies_importedCookieOverridesDuplicateWebViewCookie() {
+        val webViewCookie =
+            Cookie(domain = "example.com", path = "/", name = "session", value = "webview")
+        val importedCookie =
+            Cookie(domain = "example.com", path = "/", name = "session", value = "imported")
+
+        val cookies =
+            mergeRuntimeCookies(
+                webViewCookies = listOf(webViewCookie),
+                importedCookies = listOf(importedCookie),
+            )
+
+        assertEquals(1, cookies.size)
+        assertEquals("imported", cookies.single().value)
+    }
+}

--- a/app/src/test/java/com/junkfood/seal/ui/page/settings/network/CookieParserTest.kt
+++ b/app/src/test/java/com/junkfood/seal/ui/page/settings/network/CookieParserTest.kt
@@ -110,6 +110,32 @@ class CookieParserTest {
     }
 
     @Test
+    fun groupCookiesByDomain_groupsLeadingDotWithBareDomain() {
+        val bareDomainCookie = Cookie(domain = "example.com", name = "session", value = "bare")
+        val leadingDotCookie = Cookie(domain = ".example.com", name = "auth", value = "dot")
+
+        val groups = CookieParser.groupCookiesByDomain(listOf(bareDomainCookie, leadingDotCookie))
+
+        assertEquals(setOf("example.com"), groups.keys)
+        assertEquals(listOf(bareDomainCookie, leadingDotCookie), groups.getValue("example.com"))
+    }
+
+    @Test
+    fun groupCookiesByDomain_splitsSubdomainsAndSeparateSites() {
+        val rootCookie = Cookie(domain = ".example.com", name = "root", value = "1")
+        val subdomainCookie = Cookie(domain = "account.example.com", name = "account", value = "2")
+        val otherCookie = Cookie(domain = "example.org", name = "other", value = "3")
+
+        val groups =
+            CookieParser.groupCookiesByDomain(listOf(rootCookie, subdomainCookie, otherCookie))
+
+        assertEquals(setOf("example.com", "account.example.com", "example.org"), groups.keys)
+        assertEquals(listOf(rootCookie), groups.getValue("example.com"))
+        assertEquals(listOf(subdomainCookie), groups.getValue("account.example.com"))
+        assertEquals(listOf(otherCookie), groups.getValue("example.org"))
+    }
+
+    @Test
     fun mergeRuntimeCookies_keepsImportedCookiesWhenWebViewIsEmpty() {
         val importedCookie = Cookie(domain = "example.com", name = "session", value = "imported")
 


### PR DESCRIPTION
# PR Draft: Import Netscape Cookie Profiles

## Summary

Adds Netscape-format cookie import support to the existing Settings -> Network -> Cookies workflow. Users can now import cookies from the clipboard or a selected text file, review the parsed result before saving, and use imported cookie profiles in the same runtime `cookies.txt` flow that Seal already passes to yt-dlp.

This keeps the feature aligned with Seal's role as a simple GUI for yt-dlp: yt-dlp already supports Netscape cookie files via `--cookies`, and this change makes that supported path easier to use from the app.

## What Changed

- Added a reusable Netscape cookie parser that accepts standard cookie file comments, headers, and `#HttpOnly_` rows, then normalizes valid entries into Seal's existing cookie model.
- Added cookie import actions to Settings -> Network -> Cookies, below the existing `Generate new cookies` action:
  - import from clipboard;
  - import from a text file selected through Android's document picker.
- Added an import confirmation step that shows safe summary information before saving, without exposing raw cookie names, values, or full cookie text in the UI.
- Saves imported cookies as existing `CookieProfile` records, so users can still edit or delete profiles through the current Cookies settings screen.
- Automatically splits multi-site cookie imports into separate profiles by normalized domain, while keeping single-site imports editable with a custom saved URL or label.
- Updates runtime cookie generation so downloads receive both WebView-generated cookies and imported cookie profiles through the same internal `cookies.txt` file.
- Adds unit coverage for parser behavior, duplicate handling, domain grouping, round-trip formatting, and runtime cookie merging.

## User Impact

- Users with an existing browser-extension `cookies.txt` export no longer need to regenerate cookies through Seal's WebView before downloading protected or authenticated content.
- Multi-site cookie exports are easier to manage because Seal separates them into domain-specific profiles instead of storing one opaque combined profile.
- The import flow avoids accidental secret exposure by requiring confirmation and only displaying aggregate cookie/domain counts.

## Screenshots / Demo

###  Settings -> Network -> Cookies with the new import actions.

<img width="1220" height="2656" alt="ffdb7b8af88cd9c5b1246579b2c0c711" src="https://github.com/user-attachments/assets/a5a1c53f-6e81-4a29-83e4-1cd623aab9f8" />

### Import confirmation dialog for a valid cookie file.

<img width="1220" height="2656" alt="8c16e4bd957405548d9c70d2831ba396" src="https://github.com/user-attachments/assets/4fb8d36f-d15a-4eac-84c7-3a52b35ae22b" /><img width="1220" height="2656" alt="41b30225e838ba02df76e46fd56da10e" src="https://github.com/user-attachments/assets/06f26d4f-2a41-41e5-ab01-499f671c5755" />

### Resulting domain-split cookie profiles after import.

<img width="1220" height="2656" alt="f29237349839606a2eb7d054a31bd7c6" src="https://github.com/user-attachments/assets/db524737-3aee-44ee-b17a-87e73d5201aa" />

## Testing

- [x] `git diff --check`
- [x] `./gradlew :app:testGenericDebugUnitTest --tests com.junkfood.seal.ui.page.settings.network.CookieParserTest`
- [x] `./gradlew :app:assembleGenericDebug`

## Notes

- This does not add browser-profile extraction, JSON cookie import, `Set-Cookie` header import, new storage permissions, or a database schema migration.
- New source strings were added only to `values/strings.xml`; broader translations can follow the existing Weblate workflow.
- The branch was reviewed against README/CONTRIBUTING expectations: the feature remains a GUI shortcut for yt-dlp-supported Netscape cookies and uses the existing Kotlin/Compose/Material 3 app structure.