### PR TITLE
Add rotating feature tips to the empty download screen

### DIFF
--- a/app/src/main/java/com/junkfood/seal/ui/page/downloadv2/DownloadPageV2.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/downloadv2/DownloadPageV2.kt
@@ -2,9 +2,14 @@ package com.junkfood.seal.ui.page.downloadv2
 
 import android.content.Intent
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.animateTo
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.horizontalScroll
@@ -38,6 +43,7 @@ import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.TipsAndUpdates
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FloatingActionButton
@@ -57,6 +63,7 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -106,10 +113,10 @@ import com.junkfood.seal.ui.component.SealModalBottomSheet
 import com.junkfood.seal.ui.component.SelectionGroupDefaults
 import com.junkfood.seal.ui.component.SelectionGroupItem
 import com.junkfood.seal.ui.component.SelectionGroupRow
-import com.junkfood.seal.ui.page.downloadv2.configure.DownloadDialogViewModel.Action
 import com.junkfood.seal.ui.page.downloadv2.configure.Config
 import com.junkfood.seal.ui.page.downloadv2.configure.DownloadDialog
 import com.junkfood.seal.ui.page.downloadv2.configure.DownloadDialogViewModel
+import com.junkfood.seal.ui.page.downloadv2.configure.DownloadDialogViewModel.Action
 import com.junkfood.seal.ui.page.downloadv2.configure.FormatPage
 import com.junkfood.seal.ui.page.downloadv2.configure.PlaylistSelectionPage
 import com.junkfood.seal.ui.page.downloadv2.configure.PreferencesMock
@@ -652,7 +659,69 @@ private fun DownloadQueuePlaceholder(modifier: Modifier = Modifier) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
                 )
+                Spacer(Modifier.height(28.dp))
+                RotatingDownloadTip()
             }
+        }
+    }
+}
+
+private const val TipRotationIntervalMillis = 7_000L
+
+private val downloadTips =
+    listOf(
+        R.string.tip_share,
+        R.string.tip_save_as_audio,
+        R.string.tip_download_playlist,
+        R.string.tip_sponsorblock,
+        R.string.tip_embed_subtitles,
+        R.string.tip_embed_metadata,
+        R.string.tip_custom_command,
+        R.string.tip_cookies,
+    )
+
+/**
+ * A subtle, auto-rotating "Did you know?" tip shown on the empty download screen. It starts on a
+ * random tip and cross-fades to the next one every few seconds to help users discover features.
+ */
+@Composable
+private fun RotatingDownloadTip(modifier: Modifier = Modifier) {
+    if (downloadTips.isEmpty()) return
+    val startIndex = remember { downloadTips.indices.random() }
+    var step by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(TipRotationIntervalMillis)
+            step++
+        }
+    }
+
+    val tipRes = downloadTips[(startIndex + step) % downloadTips.size]
+
+    Row(
+        modifier = modifier.widthIn(max = 360.dp).padding(horizontal = 24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.TipsAndUpdates,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        AnimatedContent(
+            targetState = tipRes,
+            transitionSpec = { fadeIn(tween(400)) togetherWith fadeOut(tween(400)) },
+            label = "download tip",
+        ) { res ->
+            Text(
+                text = stringResource(res),
+                modifier = Modifier.padding(start = 8.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,6 +424,15 @@
     <string name="task_added">Task added to queue</string>
     <string name="you_ll_find_your_downloads_here">You\'ll find your downloads here</string>
     <string name="download_hint">Tap on the download button or share a video link to this app to start a download</string>
+    <!-- Rotating tips shown on the empty download screen -->
+    <string name="tip_share">Share a video link to Seal from any app to start downloading right away.</string>
+    <string name="tip_save_as_audio">Turn on \"Save as audio\" to grab just the audio track from any video.</string>
+    <string name="tip_download_playlist">Enable \"Download playlist\" to download every video in a playlist at once.</string>
+    <string name="tip_sponsorblock">Switch on SponsorBlock to automatically skip or remove sponsored segments.</string>
+    <string name="tip_embed_subtitles">Use \"Embed subtitles\" to bake captions right into your videos.</string>
+    <string name="tip_embed_metadata">Enable \"Embed metadata\" to add thumbnails and tags to your audio files.</string>
+    <string name="tip_custom_command">Power user? Save custom command templates to run yt-dlp options directly.</string>
+    <string name="tip_cookies">Need to download from a site that requires login? Generate cookies in Settings.</string>
     <string name="status_downloaded">Downloaded</string>
     <string name="all">All</string>
     <string name="select_multiple_link">Select from %1$d links</string>


### PR DESCRIPTION
## What

Adds a small, auto-rotating "Did you know?"-style tip below the existing empty-state hint on the **Download queue** screen. It surfaces 8 tips that point users at existing features they might not have discovered yet.

Addresses #605.

## Why

#605 asks for more in-app tips. The empty download screen is the first thing new users see before their first download, which makes it a natural, low-friction place for feature discovery — no new screens, settings, or navigation.

## Details

- New `RotatingDownloadTip` composable in `DownloadPageV2.kt`, rendered inside `DownloadQueuePlaceholder` (so it only appears when the visible list is empty).
- Cross-fades between tips every 7s, starting on a random tip on each launch.
- Reuses existing styling — `bodySmall` / `onSurfaceVariant` text with a subtle `TipsAndUpdates` icon in the primary color — to stay consistent with the hint above it.
- 8 new translatable strings in the default `values/strings.xml`, each referencing a real feature: **Save as audio**, **Download playlist**, **SponsorBlock**, **Embed subtitles**, **Embed metadata**, **custom command templates**, **cookies**, and **share-to-Seal**.

## Open to feedback

Happy to drop the rotation in favor of a single static random tip, or adjust the wording/count, if you'd prefer something lighter. Just let me know.

## Testing

Built and run on a physical device (Android 11). The empty-state renders correctly and tips rotate as expected.
