### PR TITLE
feat: sanitize filenames to strip FAT32-illegal characters before saving

### DIFF
--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -832,11 +832,13 @@ object DownloadUtil {
     ): Result<List<String>> =
         preferences.run {
             val fileName =
-                preferences.newTitle.ifEmpty {
-                    videoInfo.filename
-                        ?: videoInfo.requestedDownloads?.firstOrNull()?.filename
-                        ?: videoInfo.title
-                }
+                FileUtil.sanitizeFileName(
+                    preferences.newTitle.ifEmpty {
+                        videoInfo.filename
+                            ?: videoInfo.requestedDownloads?.firstOrNull()?.filename
+                            ?: videoInfo.title
+                    }
+                )
 
             Log.d(TAG, "onFinishDownloading: $fileName")
             if (sdcard) {

--- a/app/src/main/java/com/junkfood/seal/util/FileUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/FileUtil.kt
@@ -98,6 +98,16 @@ object FileUtil {
             }
         }
 
+    // Characters that FAT32/exFAT (common on SD cards and some MTP targets) reject.
+    // Keeping spaces and non-ASCII letters intact so titles stay readable.
+    private val ILLEGAL_FILENAME_CHARS = Regex("""[\\/:*?"<>|]""")
+
+    fun sanitizeFileName(name: String): String {
+        val sanitized = ILLEGAL_FILENAME_CHARS.replace(name, "_")
+        // Trim trailing dots/spaces which Windows rejects and some Android OEMs mishandle.
+        return sanitized.trimEnd('.', ' ').ifEmpty { "download" }
+    }
+
     fun deleteFile(path: String) =
         path.runCatching {
             if (!File(path).delete()) DocumentFile.fromSingleUri(context, Uri.parse(this))?.delete()


### PR DESCRIPTION
## Summary

Closes #2545

On FAT32/exFAT external storage (SD cards, most MTP targets), filenames containing `\ / : * ? " < > |` cause silent save failures or produce broken files. This adds a lightweight sanitization step that replaces those characters with underscores, preserving spaces and non-ASCII letters so titles stay readable.

## Changes

- `FileUtil.sanitizeFileName(name: String): String` — strips illegal chars, trims trailing dots/spaces, falls back to `"download"` if the result would be blank.
- `DownloadUtil.onFinishDownloading` — applies `sanitizeFileName()` at the single point where the final filename is resolved.

The existing `--restrict-filenames` yt-dlp option is unaffected for users who want full ASCII-safe output.

## Test plan

- [ ] Download a video whose title contains `:` or `?` (common in YouTube titles); file saves successfully on external storage
- [ ] Normal titles without special characters are unchanged
- [ ] User-overridden title (via rename dialog) is also sanitized