### PR TITLE
feat(cookies): add Netscape cookies.txt import

### DIFF
--- a/app/src/main/java/com/junkfood/seal/App.kt
+++ b/app/src/main/java/com/junkfood/seal/App.kt
@@ -24,6 +24,7 @@ import com.junkfood.seal.ui.page.settings.network.CookiesViewModel
 import com.junkfood.seal.ui.page.videolist.VideoListViewModel
 import com.junkfood.seal.util.AUDIO_DIRECTORY
 import com.junkfood.seal.util.COMMAND_DIRECTORY
+import com.junkfood.seal.util.DatabaseUtil
 import com.junkfood.seal.util.DownloadUtil
 import com.junkfood.seal.util.FileUtil
 import com.junkfood.seal.util.FileUtil.createEmptyFile
@@ -91,13 +92,16 @@ class App : Application() {
                 YoutubeDL.init(this@App)
                 FFmpeg.init(this@App)
                 Aria2c.init(this@App)
-                DownloadUtil.getCookiesContentFromDatabase().getOrNull()?.let {
-                    FileUtil.writeContentToFile(it, getCookiesFile())
-                }
+                migrateLegacyCookies()
+                writeCookiesFile()
                 UpdateUtil.deleteOutdatedApk()
             } catch (th: Throwable) {
                 withContext(Dispatchers.Main) { startCrashReportActivity(th) }
             }
+        }
+
+        applicationScope.launch(Dispatchers.IO) {
+            DatabaseUtil.getCookiesFlow().collect { writeCookiesFile() }
         }
 
         videoDownloadDir = VIDEO_DIRECTORY.getString(getExternalDownloadDirectory().absolutePath)
@@ -121,6 +125,23 @@ class App : Application() {
                     putExtra("error_report", getVersionReport() + "\n" + th.stackTraceToString())
                 }
         )
+    }
+
+    private suspend fun migrateLegacyCookies() {
+        val profiles = DatabaseUtil.getCookieProfileList()
+        val legacyProfiles = profiles.filter { it.content.isBlank() }
+        if (legacyProfiles.isEmpty()) return
+        DownloadUtil.extractCookiesFromWebView().onSuccess { content ->
+            legacyProfiles.forEach { profile ->
+                DatabaseUtil.updateCookieProfile(profile.copy(content = content))
+            }
+        }
+    }
+
+    private suspend fun writeCookiesFile() {
+        DownloadUtil.getCookiesContentFromDatabase().getOrNull()?.let {
+            FileUtil.writeContentToFile(it, getCookiesFile())
+        } ?: getCookiesFile().delete()
     }
 
     companion object {

--- a/app/src/main/java/com/junkfood/seal/database/VideoInfoDao.kt
+++ b/app/src/main/java/com/junkfood/seal/database/VideoInfoDao.kt
@@ -54,6 +54,13 @@ interface VideoInfoDao {
 
     @Query("select * from CookieProfile") fun getCookieProfileFlow(): Flow<List<CookieProfile>>
 
+    @Query("select * from CookieProfile") suspend fun getCookieProfileList(): List<CookieProfile>
+
+    @Query("select * from CookieProfile where url=:url limit 1")
+    suspend fun getCookieProfileByUrl(url: String): CookieProfile?
+
+    @Query("delete from CookieProfile") suspend fun deleteAllCookieProfiles()
+
     @Insert suspend fun insertTemplate(template: CommandTemplate): Long
 
     @Insert @Transaction suspend fun importTemplates(templateList: List<CommandTemplate>)

--- a/app/src/main/java/com/junkfood/seal/ui/page/AppEntry.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/AppEntry.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -33,6 +34,7 @@ import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.junkfood.seal.App
 import com.junkfood.seal.R
+import com.junkfood.seal.database.objects.CookieProfile
 import com.junkfood.seal.ui.common.HapticFeedback.slightHapticFeedback
 import com.junkfood.seal.ui.common.LocalWindowWidthState
 import com.junkfood.seal.ui.common.Route
@@ -66,6 +68,9 @@ import com.junkfood.seal.ui.page.settings.network.NetworkPreferences
 import com.junkfood.seal.ui.page.settings.network.WebViewPage
 import com.junkfood.seal.ui.page.settings.troubleshooting.TroubleShootingPage
 import com.junkfood.seal.ui.page.videolist.VideoListPage
+import com.junkfood.seal.util.DatabaseUtil
+import com.junkfood.seal.util.DownloadUtil
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
@@ -257,6 +262,20 @@ fun NavGraphBuilder.settingsGraph(
             WebViewPage(cookiesViewModel = cookiesViewModel) {
                 onNavigateBack()
                 CookieManager.getInstance().flush()
+                cookiesViewModel.viewModelScope.launch(Dispatchers.IO) {
+                    val url = cookiesViewModel.stateFlow.value.editingCookieProfile.url
+                    DownloadUtil.extractCookiesFromWebView().onSuccess { content ->
+                        val existing = DatabaseUtil.getCookieProfileByUrl(url)
+                        val profile =
+                            existing?.copy(content = content)
+                                ?: CookieProfile(id = 0, url = url, content = content)
+                        if (existing != null) {
+                            DatabaseUtil.updateCookieProfile(profile)
+                        } else {
+                            DatabaseUtil.insertCookieProfile(profile)
+                        }
+                    }
+                }
             }
         }
         animatedComposable(Route.TROUBLESHOOTING) {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -257,6 +257,7 @@ fun CookieProfilePage(
                         DropdownMenuItem(
                             leadingIcon = { Icon(Icons.Outlined.DeleteForever, null) },
                             text = { Text(stringResource(id = R.string.clear_all_cookies)) },
+                            enabled = cookieList.isNotEmpty(),
                             onClick = {
                                 expanded = false
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -91,6 +91,7 @@ import com.junkfood.seal.ui.theme.SealTheme
 import com.junkfood.seal.ui.theme.generateLabelColor
 import com.junkfood.seal.util.COOKIES
 import com.junkfood.seal.util.DatabaseUtil
+import com.junkfood.seal.util.DownloadUtil
 import com.junkfood.seal.util.DownloadUtil.parseNetscapeCookies
 import com.junkfood.seal.util.DownloadUtil.toCookiesFileContent
 import com.junkfood.seal.util.PreferenceUtil.getBoolean
@@ -332,7 +333,10 @@ fun CookieProfilePage(
             cookiesViewModel = cookiesViewModel,
             navigateToCookieGeneratorPage = {
                 cookiesViewModel.updateCookieProfile()
-                navigateToCookieGeneratorPage()
+                scope.launch(Dispatchers.IO) {
+                    DownloadUtil.syncCookiesToWebView()
+                    withContext(Dispatchers.Main) { navigateToCookieGeneratorPage() }
+                }
             },
         ) {
             showEditDialog = false

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.outlined.Cookie
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DeleteForever
 import androidx.compose.material.icons.outlined.FileCopy
+import androidx.compose.material.icons.outlined.FileOpen
 import androidx.compose.material.icons.outlined.GeneratingTokens
 import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.MoreVert
@@ -89,13 +90,16 @@ import com.junkfood.seal.ui.component.TextButtonWithIcon
 import com.junkfood.seal.ui.theme.SealTheme
 import com.junkfood.seal.ui.theme.generateLabelColor
 import com.junkfood.seal.util.COOKIES
+import com.junkfood.seal.util.DatabaseUtil
 import com.junkfood.seal.util.DownloadUtil
+import com.junkfood.seal.util.DownloadUtil.parseNetscapeCookies
 import com.junkfood.seal.util.DownloadUtil.toCookiesFileContent
 import com.junkfood.seal.util.FileUtil
 import com.junkfood.seal.util.FileUtil.getCookiesFile
 import com.junkfood.seal.util.PreferenceUtil.getBoolean
 import com.junkfood.seal.util.PreferenceUtil.updateBoolean
 import com.junkfood.seal.util.USER_AGENT
+import com.junkfood.seal.util.ToastUtil
 import com.junkfood.seal.util.matchUrlFromClipboard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -150,6 +154,54 @@ fun CookieProfilePage(
                 scope.launch(Dispatchers.IO) {
                     context.contentResolver.openOutputStream(uri)?.use {
                         it.write(cookieList.toCookiesFileContent().toByteArray())
+                    }
+                }
+            }
+        }
+
+    val importLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenDocument()
+        ) { uri ->
+            uri?.let {
+                scope.launch(Dispatchers.IO) {
+                    runCatching {
+                        val content = context.contentResolver.openInputStream(it)?.use { stream ->
+                            stream.bufferedReader().readText()
+                        } ?: throw Exception("Failed to read file")
+                        val importedCookies = parseNetscapeCookies(content)
+                        if (importedCookies.isEmpty()) throw Exception("No valid cookies found")
+                        val contentString = importedCookies.toCookiesFileContent()
+                        FileUtil.writeContentToFile(contentString, context.getCookiesFile())
+                        importedCookies.forEach { cookie ->
+                            val domain =
+                                if (cookie.domain.startsWith(".")) cookie.domain.drop(1)
+                                else cookie.domain
+                            val url = "https://$domain${cookie.path}"
+                            cookieManager.setCookie(url, "${cookie.name}=${cookie.value}")
+                        }
+                        cookieManager.flush()
+                        importedCookies.groupBy { it.domain }.forEach { (domain, cookies) ->
+                            DatabaseUtil.insertCookieProfile(
+                                CookieProfile(
+                                    id = 0,
+                                    url = "https://$domain",
+                                    content = cookies.toCookiesFileContent(),
+                                )
+                            )
+                        }
+                        importedCookies
+                    }.onSuccess { importedCookies ->
+                        withContext(Dispatchers.Main) {
+                            cookieList = importedCookies
+                            ToastUtil.makeToast(
+                                context.getString(R.string.cookies_imported, importedCookies.size)
+                            )
+                        }
+                    }.onFailure {
+                        withContext(Dispatchers.Main) {
+                            ToastUtil.makeToast(context.getString(R.string.import_failed))
+                        }
                     }
                 }
             }
@@ -210,6 +262,14 @@ fun CookieProfilePage(
                             },
                         )
                         DropdownMenuItem(
+                            leadingIcon = { Icon(Icons.Outlined.FileOpen, null) },
+                            text = { Text(stringResource(id = R.string.import_from_file)) },
+                            onClick = {
+                                expanded = false
+                                importLauncher.launch(arrayOf("text/plain", "text/*"))
+                            },
+                        )
+                        DropdownMenuItem(
                             leadingIcon = { Icon(Icons.Outlined.DeleteForever, null) },
                             text = { Text(stringResource(id = R.string.clear_all_cookies)) },
                             onClick = {
@@ -235,7 +295,7 @@ fun CookieProfilePage(
                             isCookieEnabled = false
                             COOKIES.updateBoolean(false)
                         } else if (
-                            (cookies.isEmpty() || !cookieManager.hasCookies()) && !isCookieEnabled
+                            (cookies.isEmpty() || (cookieList.isEmpty() && !cookieManager.hasCookies())) && !isCookieEnabled
                         ) {
                             showHelpDialog = true
                         } else {

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -236,6 +236,14 @@ fun CookieProfilePage(
                             onClick = ::toggleUserAgent,
                         )
                         DropdownMenuItem(
+                            leadingIcon = { Icon(Icons.Outlined.FileOpen, null) },
+                            text = { Text(stringResource(id = R.string.import_from_file)) },
+                            onClick = {
+                                expanded = false
+                                importLauncher.launch(arrayOf("text/plain", "text/*"))
+                            },
+                        )
+                        DropdownMenuItem(
                             leadingIcon = { Icon(Icons.Outlined.FileCopy, null) },
                             text = { Text(stringResource(id = R.string.export_to_file)) },
                             enabled = cookieList.isNotEmpty(),
@@ -244,14 +252,6 @@ fun CookieProfilePage(
                                 exportLauncher.launch(
                                     "cookies_exported${System.currentTimeMillis()}.txt"
                                 )
-                            },
-                        )
-                        DropdownMenuItem(
-                            leadingIcon = { Icon(Icons.Outlined.FileOpen, null) },
-                            text = { Text(stringResource(id = R.string.import_from_file)) },
-                            onClick = {
-                                expanded = false
-                                importLauncher.launch(arrayOf("text/plain", "text/*"))
                             },
                         )
                         DropdownMenuItem(

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/network/CookieProfilesPage.kt
@@ -49,9 +49,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -91,11 +91,8 @@ import com.junkfood.seal.ui.theme.SealTheme
 import com.junkfood.seal.ui.theme.generateLabelColor
 import com.junkfood.seal.util.COOKIES
 import com.junkfood.seal.util.DatabaseUtil
-import com.junkfood.seal.util.DownloadUtil
 import com.junkfood.seal.util.DownloadUtil.parseNetscapeCookies
 import com.junkfood.seal.util.DownloadUtil.toCookiesFileContent
-import com.junkfood.seal.util.FileUtil
-import com.junkfood.seal.util.FileUtil.getCookiesFile
 import com.junkfood.seal.util.PreferenceUtil.getBoolean
 import com.junkfood.seal.util.PreferenceUtil.updateBoolean
 import com.junkfood.seal.util.USER_AGENT
@@ -125,26 +122,15 @@ fun CookieProfilePage(
     val state by cookiesViewModel.stateFlow.collectAsStateWithLifecycle()
     var showClearCookieDialog by remember { mutableStateOf(false) }
     var isCookieEnabled by remember { mutableStateOf(COOKIES.getBoolean()) }
-    val cookieManager = CookieManager.getInstance()
     var showHelpDialog by remember { mutableStateOf(false) }
     val view = LocalView.current
 
-    var cookieList by remember { mutableStateOf(listOf<Cookie>()) }
-
-    var shouldUpdateCookies by remember { mutableStateOf(false) }
+    val cookieList by remember(cookies) {
+        derivedStateOf { cookies.flatMap { parseNetscapeCookies(it.content) } }
+    }
 
     var showEditDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
-
-    DisposableEffect(shouldUpdateCookies) {
-        scope.launch(Dispatchers.IO) {
-            DownloadUtil.getCookieListFromDatabase().getOrNull()?.let {
-                cookieList = it
-                FileUtil.writeContentToFile(it.toCookiesFileContent(), context.getCookiesFile())
-            }
-        }
-        onDispose { shouldUpdateCookies = false }
-    }
 
     val exportLauncher =
         rememberLauncherForActivityResult(
@@ -171,29 +157,27 @@ fun CookieProfilePage(
                         } ?: throw Exception("Failed to read file")
                         val importedCookies = parseNetscapeCookies(content)
                         if (importedCookies.isEmpty()) throw Exception("No valid cookies found")
-                        val contentString = importedCookies.toCookiesFileContent()
-                        FileUtil.writeContentToFile(contentString, context.getCookiesFile())
-                        importedCookies.forEach { cookie ->
-                            val domain =
-                                if (cookie.domain.startsWith(".")) cookie.domain.drop(1)
-                                else cookie.domain
-                            val url = "https://$domain${cookie.path}"
-                            cookieManager.setCookie(url, "${cookie.name}=${cookie.value}")
-                        }
-                        cookieManager.flush()
-                        importedCookies.groupBy { it.domain }.forEach { (domain, cookies) ->
-                            DatabaseUtil.insertCookieProfile(
-                                CookieProfile(
-                                    id = 0,
-                                    url = "https://$domain",
-                                    content = cookies.toCookiesFileContent(),
+                        importedCookies.groupBy { it.domain }.forEach { (domain, cookiesForDomain) ->
+                            val url = "https://${domain.removePrefix(".")}"
+                            val existing = DatabaseUtil.getCookieProfileByUrl(url)
+                            val profile =
+                                existing?.copy(
+                                    content = cookiesForDomain.toCookiesFileContent()
                                 )
-                            )
+                                    ?: CookieProfile(
+                                        id = 0,
+                                        url = url,
+                                        content = cookiesForDomain.toCookiesFileContent(),
+                                    )
+                            if (existing != null) {
+                                DatabaseUtil.updateCookieProfile(profile)
+                            } else {
+                                DatabaseUtil.insertCookieProfile(profile)
+                            }
                         }
                         importedCookies
                     }.onSuccess { importedCookies ->
                         withContext(Dispatchers.Main) {
-                            cookieList = importedCookies
                             ToastUtil.makeToast(
                                 context.getString(R.string.cookies_imported, importedCookies.size)
                             )
@@ -294,9 +278,7 @@ fun CookieProfilePage(
                         if (isCookieEnabled) {
                             isCookieEnabled = false
                             COOKIES.updateBoolean(false)
-                        } else if (
-                            (cookies.isEmpty() || (cookieList.isEmpty() && !cookieManager.hasCookies())) && !isCookieEnabled
-                        ) {
+                        } else if (cookies.isEmpty()) {
                             showHelpDialog = true
                         } else {
                             isCookieEnabled = true
@@ -354,7 +336,6 @@ fun CookieProfilePage(
             },
         ) {
             showEditDialog = false
-            shouldUpdateCookies = true
         }
     }
 
@@ -371,9 +352,10 @@ fun CookieProfilePage(
     if (showClearCookieDialog) {
         ClearCookiesDialog(onDismissRequest = { showClearCookieDialog = false }) {
             view.slightHapticFeedback()
-            scope
-                .launch(Dispatchers.IO) { CookieManager.getInstance().removeAllCookies(null) }
-                .invokeOnCompletion { shouldUpdateCookies = true }
+            scope.launch(Dispatchers.IO) {
+                CookieManager.getInstance().removeAllCookies(null)
+                DatabaseUtil.deleteAllCookieProfiles()
+            }
         }
     }
 }

--- a/app/src/main/java/com/junkfood/seal/util/DatabaseUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DatabaseUtil.kt
@@ -49,7 +49,13 @@ object DatabaseUtil {
 
     suspend fun getCookieById(id: Int) = dao.getCookieById(id)
 
+    suspend fun getCookieProfileByUrl(url: String) = dao.getCookieProfileByUrl(url)
+
+    suspend fun getCookieProfileList() = dao.getCookieProfileList()
+
     suspend fun deleteCookieProfile(profile: CookieProfile) = dao.deleteCookieProfile(profile)
+
+    suspend fun deleteAllCookieProfiles() = dao.deleteAllCookieProfiles()
 
     suspend fun insertCookieProfile(profile: CookieProfile) = dao.insertCookieProfile(profile)
 

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -434,6 +434,31 @@ object DownloadUtil {
             }
     }
 
+    suspend fun syncCookiesToWebView() {
+        withContext(Dispatchers.IO) {
+            DatabaseUtil.getCookieProfileList().forEach { profile ->
+                parseNetscapeCookies(profile.content).forEach { cookie ->
+                    val domain = cookie.domain.removePrefix(".")
+                    val url = "https://$domain${cookie.path}"
+                    CookieManager.getInstance().setCookie(url, cookie.toSetCookieHeader())
+                }
+            }
+            CookieManager.getInstance().flush()
+        }
+    }
+
+    private fun Cookie.toSetCookieHeader(): String {
+        val expiresPart =
+            if (expiry > 0) "; Expires=${formatHttpDate(expiry)}" else ""
+        val securePart = if (secure) "; Secure" else ""
+        return "$name=$value; Domain=$domain; Path=$path$expiresPart$securePart"
+    }
+
+    private fun formatHttpDate(unixSeconds: Long): String =
+        java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", java.util.Locale.US).apply {
+            timeZone = java.util.TimeZone.getTimeZone("GMT")
+        }.format(java.util.Date(unixSeconds * 1000L))
+
     fun List<Cookie>.toCookiesFileContent(): String =
         this.fold(StringBuilder(COOKIE_HEADER)) { acc, cookie ->
                 acc.append(cookie.toNetscapeCookieString()).append("\n")

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -427,6 +427,33 @@ object DownloadUtil {
             }
             .toString()
 
+    fun parseNetscapeCookies(content: String): List<Cookie> {
+        val cookies = mutableListOf<Cookie>()
+        content.lines().forEach { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) return@forEach
+            val processed =
+                if (trimmed.startsWith("#HttpOnly_")) trimmed.removePrefix("#HttpOnly_")
+                else if (trimmed.startsWith("#")) return@forEach
+                else trimmed
+            val fields = processed.split("\t")
+            if (fields.size >= 7) {
+                cookies.add(
+                    Cookie(
+                        domain = fields[0],
+                        includeSubdomains = fields[1].uppercase() == "TRUE",
+                        path = fields[2],
+                        secure = fields[3].uppercase() == "TRUE",
+                        expiry = fields[4].toLongOrNull() ?: 0L,
+                        name = fields[5],
+                        value = fields[6],
+                    )
+                )
+            }
+        }
+        return cookies
+    }
+
     fun getCookiesContentFromDatabase(): Result<String> =
         getCookieListFromDatabase().mapCatching { it.toCookiesFileContent() }
 

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -372,11 +372,23 @@ object DownloadUtil {
         this.addOption("--download-archive", context.getArchiveFile().absolutePath)
 
     @CheckResult
-    fun getCookieListFromDatabase(): Result<List<Cookie>> = runCatching {
-        CookieManager.getInstance().run {
-            if (!hasCookies()) throw Exception("There is no cookies in the database!")
-            flush()
-        }
+    suspend fun getCookieListFromDatabase(): Result<List<Cookie>> = runCatching {
+        val profiles = DatabaseUtil.getCookieProfileList()
+        if (profiles.isEmpty()) throw Exception("There is no cookies in the database!")
+        profiles.flatMap { parseNetscapeCookies(it.content) }
+            .ifEmpty { throw Exception("There is no cookies in the database!") }
+    }
+
+    suspend fun getCookiesContentFromDatabase(): Result<String> = runCatching {
+        val profiles = DatabaseUtil.getCookieProfileList()
+        if (profiles.isEmpty()) throw Exception("There is no cookies in the database!")
+        profiles.joinToString(separator = "") { it.content }
+            .ifEmpty { throw Exception("There is no cookies in the database!") }
+    }
+
+    @CheckResult
+    fun extractCookiesFromWebView(): Result<String> = runCatching {
+        CookieManager.getInstance().flush()
         SQLiteDatabase.openDatabase(
                 context.dataDir.resolve("app_webview/Default/Cookies").absolutePath,
                 null,
@@ -417,7 +429,8 @@ object DownloadUtil {
                     close()
                 }
                 close()
-                cookieList
+                if (cookieList.isEmpty()) throw Exception("No cookies found in WebView")
+                cookieList.toCookiesFileContent()
             }
     }
 
@@ -453,9 +466,6 @@ object DownloadUtil {
         }
         return cookies
     }
-
-    fun getCookiesContentFromDatabase(): Result<String> =
-        getCookieListFromDatabase().mapCatching { it.toCookiesFileContent() }
 
     private fun YoutubeDLRequest.enableAria2c(): YoutubeDLRequest =
         this.addOption("--downloader", "libaria2c.so")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,7 @@
     <string name="remove_cookie_profile_desc">Remove this entry for \"%1$s\"? Please note that the cookies stored for this site will not be cleared.</string>
     <string name="custom_command_enabled_hint">Some options are unavailable when using custom command</string>
     <string name="how_does_it_work">How does it work?</string>
-    <string name="cookies_usage_msg">Downloading from some sites requires account authentication information. Click \"Generate new cookies\", enter the URL of the website and then log in with your account in the browser page, the app will generate it for you.</string>
+    <string name="cookies_usage_msg">Downloading from some sites requires account authentication. You can either log in via the in-app browser (Generate new cookies) or import a Netscape-format cookies.txt file from the menu. Both methods store the cookies in Seal for use with yt-dlp.</string>
     <string name="custom_command_usage_msg">yt-dlp is a powerful command-line tool for downloading videos. Seal makes it easier to use yt-dlp by providing an intuitive GUI, presets for common commands, and other additional features.\n\nFor advanced usage of yt-dlp, Seal allows you to create, save and execute custom command templates directly, just like in a terminal.\n\nWhen using custom commands, most of the GUI options and features would be disabled.</string>
     <string name="telegram_channel">Telegram channel</string>
     <string name="matrix_space">Matrix space</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,10 @@
     <string name="remove_multiple_templates_msg">Remove %1$s from command templates for good?</string>
     <string name="ua_header">User-Agent header</string>
     <string name="export_to_file">Export to file</string>
+    <string name="import_from_file">Import from file</string>
+    <string name="import_cookies_desc">Import a Netscape formatted cookies.txt file exported from your browser</string>
+    <string name="cookies_imported">%1$d cookies imported</string>
+    <string name="import_failed">Failed to import cookies</string>
     <string name="output_template">Output template</string>
     <string name="presets">Presets</string>
     <string name="output_template_desc">Specify the template for output file names</string>


### PR DESCRIPTION
close #1438. 

All code written by AI. I have manually verified that both logging in via "Generate new cookies" and the new "Import from file" option work for instagram.com

- added import from file option to the menu
- both export to file and clear all cookies option is grayed out if no cookies are saved
- tooltip help text is updated to include cookies.txt method
- "Generate new cookies" can load cookies imported from file (shows a login page)
- fixed a bug where after clearing cookies, the cookie and website count don't go to 0

<img height="350" alt="share_9132470766851403590" src="https://github.com/user-attachments/assets/decad502-9ad6-4d7f-88fa-0fc6dd87793e" />

<img height="350" alt="image" src="https://github.com/user-attachments/assets/55b6b8d5-08c1-44d2-948c-34eaae62667a" />

