### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can help translate Seal on [Hosted Weblate](https://hosted.weblate.org/proje
 
 ## ⭐️ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 Credits

--- a/translations/README-ar.md
+++ b/translations/README-ar.md
@@ -88,8 +88,8 @@
 
 ## ⭐️ تاريخ النجوم
 <p align="right">
-<a href="https://star-history.com/#JunkFood02/Seal&Timeline">
-<img src="https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline" alt="Star History Chart" />
+<a href="https://star-history.dera.page/#JunkFood02/Seal&Timeline">
+<img src="https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline" alt="Star History Chart" />
 </a>
 
 ## 🧱 الاعتمادات

--- a/translations/README-az.md
+++ b/translations/README-az.md
@@ -107,7 +107,7 @@ Siz [Hosted Weblate](https://hosted.weblate.org/projects/seal/)-də Seal-ı tər
 
 ## ⭐️ Ulduz Tarixçəsi
 
-[![Ulduz Tarixçəsi Sxemi](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Ulduz Tarixçəsi Sxemi](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 Kreditlər

--- a/translations/README-bn.md
+++ b/translations/README-bn.md
@@ -133,7 +133,7 @@ English
 
 ## ⭐️ স্টার চার্ট
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 ক্রেডিট

--- a/translations/README-fa.md
+++ b/translations/README-fa.md
@@ -88,8 +88,8 @@ Seal
 
 ## ⭐️تاریخچه امتیاز
 <p align="right">
-<a href="https://star-history.com/#JunkFood02/Seal&Timeline">
-<img src="https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline" alt="Star History Chart" />
+<a href="https://star-history.dera.page/#JunkFood02/Seal&Timeline">
+<img src="https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline" alt="Star History Chart" />
 </p>
 
 ## 🧱 منابع

--- a/translations/README-hi.md
+++ b/translations/README-hi.md
@@ -129,7 +129,7 @@ Seal हमेशा के लिए मुफ्त और ओपन-सोर
 
 ## ⭐️ स्टार इतिहास
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 ## 🧱 क्रेडिट
 

--- a/translations/README-id.md
+++ b/translations/README-id.md
@@ -105,7 +105,7 @@ Anda dapat membantu menerjemahkan Seal di [Hosted Weblate](https://hosted.weblat
 
 ## ⭐️ Sejarah bintang
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 Kredit

--- a/translations/README-it.md
+++ b/translations/README-it.md
@@ -106,7 +106,7 @@ Puoi aiutare a tradurre Seal su [Hosted Weblate](https://hosted.weblate.org/proj
 
 ## ⭐️ Storia delle Stelle
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 Crediti

--- a/translations/README-ja.md
+++ b/translations/README-ja.md
@@ -101,7 +101,7 @@ Sealの翻訳を [Hosted Weblate](https://hosted.weblate.org/projects/seal/) で
 
 ## ⭐️星の推移
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 ## 🧱 クレジット
 

--- a/translations/README-pt.md
+++ b/translations/README-pt.md
@@ -127,7 +127,7 @@ Você pode ajudar a traduzir o Seal no [Weblate Hosteado](https://hosted.weblate
 
 ## ⭐️ Linha de tempo de Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 ## 🧱 Creditos
 

--- a/translations/README-ru.md
+++ b/translations/README-ru.md
@@ -106,7 +106,7 @@ Seal всегда будет бесплатным проектом с откры
 
 ## ⭐️ График роста кол-ва звёздочек
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 ## 🧱 Особая благодарность
 

--- a/translations/README-sr.md
+++ b/translations/README-sr.md
@@ -108,7 +108,7 @@ Seal ће увек бити бесплатан и отвореног кода з
 >За слање извештаја о грешкама, захтева за функције, питања или било које друге идеје за побољшање апликације, прво прочитајте [CONTRIBUTING.md](https://github.com/JunkFood02/Seal/blob/main/CONTRIBUTING.md) за упутства и смернице. 
 
 ## ⭐️ Графикон раста броја звездица
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 Кредити 

--- a/translations/README-th.md
+++ b/translations/README-th.md
@@ -101,7 +101,7 @@ Seal
 
  ## ⭐️ประวัติ Star
 
- [![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+ [![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
  ## 🧱 เครดิต
 

--- a/translations/README-ua.md
+++ b/translations/README-ua.md
@@ -95,7 +95,7 @@
 
 ## ⭐️ Історія зірочок
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 ## 🧱 Подяки
 

--- a/translations/README-zh_Hant.md
+++ b/translations/README-zh_Hant.md
@@ -105,7 +105,7 @@ Seal 永遠提供眾人免費使用並開放原始碼。若您悅納，請考慮
 
 ## ⭐️ Star 歷程
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.com/#JunkFood02/Seal&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JunkFood02/Seal&type=Timeline)](https://star-history.dera.page/#JunkFood02/Seal&Timeline)
 
 
 ## 🧱 致謝


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This updates the chart and its link to a working replacement so visitors can once again see the project's star growth. Changes are applied consistently to the README and all translated versions.