### PR TITLE
feat(format): add option to prefer original audio track

### DIFF
--- a/app/src/main/java/com/junkfood/seal/ui/component/FormatItem.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/component/FormatItem.kt
@@ -288,11 +288,32 @@ fun FormatItem(
 
         val firstLineText = connectWithDelimiter(fileSizeText, tbrText, delimiter = " ")
 
-        val secondLineText = connectWithDelimiter(ext, codec, delimiter = " ").uppercase()
+        val langTag = if (formatInfo.isAudioOnly() && !language.isNullOrEmpty()) "[$language]" else null
+        val secondLineText = connectWithDelimiter(ext, codec, langTag, delimiter = " ").uppercase()
+
+        val audioTrackNote = buildString {
+            if (!language.isNullOrEmpty() && format?.contains(language, ignoreCase = true) != true) {
+                append("[$language]")
+            }
+            if (!formatNote.isNullOrEmpty() && format?.contains(formatNote, ignoreCase = true) != true) {
+                val cleanNote = if (formatNote.startsWith("medium, ", ignoreCase = true)) {
+                    formatNote.substringAfter("medium, ")
+                } else formatNote
+                if (isNotEmpty()) append(" ")
+                append(cleanNote)
+            }
+        }.takeIf { it.isNotBlank() }
+
+        val titleText =
+            if (audioTrackNote != null) {
+                connectWithBlank((format ?: formatId).orEmpty(), "($audioTrackNote)")
+            } else {
+                format.toString()
+            }
 
         FormatItem(
             modifier = modifier,
-            title = format.toString(),
+            title = titleText,
             containsAudio = formatInfo.containsAudio(),
             containsVideo = formatInfo.containsVideo(),
             firstLineText = firstLineText,

--- a/app/src/main/java/com/junkfood/seal/ui/page/settings/format/DownloadFormatPreferences.kt
+++ b/app/src/main/java/com/junkfood/seal/ui/page/settings/format/DownloadFormatPreferences.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.outlined.Sort
 import androidx.compose.material.icons.outlined.SpatialAudioOff
 import androidx.compose.material.icons.outlined.Subtitles
 import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material.icons.outlined.VideoFile
 import androidx.compose.material.icons.outlined.VideoSettings
 import androidx.compose.material3.AlertDialog
@@ -56,6 +57,7 @@ import com.junkfood.seal.util.FORMAT_SELECTION
 import com.junkfood.seal.util.FORMAT_SORTING
 import com.junkfood.seal.util.MERGE_MULTI_AUDIO_STREAM
 import com.junkfood.seal.util.MERGE_OUTPUT_MKV
+import com.junkfood.seal.util.PREFER_ORIGINAL_AUDIO
 import com.junkfood.seal.util.PreferenceStrings
 import com.junkfood.seal.util.PreferenceUtil
 import com.junkfood.seal.util.PreferenceUtil.getBoolean
@@ -108,6 +110,7 @@ fun DownloadFormatPreferences(onNavigateBack: () -> Unit, navigateToSubtitlePage
     var isFormatSelectionEnabled by FORMAT_SELECTION.booleanState
     var mergeAudioStream by MERGE_MULTI_AUDIO_STREAM.booleanState
     var showMergeAudioDialog by remember { mutableStateOf(false) }
+    var preferOriginalAudio by PREFER_ORIGINAL_AUDIO.booleanState
 
     Scaffold(
         modifier = Modifier.fillMaxSize().nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -198,6 +201,19 @@ fun DownloadFormatPreferences(onNavigateBack: () -> Unit, navigateToSubtitlePage
                         isArtworkCroppingEnabled = !isArtworkCroppingEnabled
                         PreferenceUtil.updateValue(CROP_ARTWORK, isArtworkCroppingEnabled)
                     }
+                }
+                item {
+                    PreferenceSwitch(
+                        title = stringResource(id = R.string.prefer_original_audio),
+                        description = stringResource(id = R.string.prefer_original_audio_desc),
+                        icon = Icons.Outlined.Translate,
+                        isChecked = preferOriginalAudio,
+                        enabled = !isCustomCommandEnabled,
+                        onClick = {
+                            preferOriginalAudio = !preferOriginalAudio
+                            PREFER_ORIGINAL_AUDIO.updateBoolean(preferOriginalAudio)
+                        },
+                    )
                 }
                 item { PreferenceSubtitle(text = stringResource(id = R.string.video)) }
                 item {

--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -239,6 +239,7 @@ object DownloadUtil {
         val forceIpv4: Boolean,
         val mergeAudioStream: Boolean,
         val mergeToMkv: Boolean,
+        val preferOriginalAudio: Boolean = false,
     ) {
         companion object {
             val EMPTY =
@@ -294,6 +295,7 @@ object DownloadUtil {
                     mergeAudioStream = false,
                     mergeToMkv = false,
                     useCustomAudioPreset = false,
+                    preferOriginalAudio = false,
                 )
 
             fun createFromPreferences(): DownloadPreferences {
@@ -353,6 +355,7 @@ object DownloadUtil {
                     mergeAudioStream = false,
                     mergeToMkv =
                         (downloadSubtitle && embedSubtitle) || MERGE_OUTPUT_MKV.getBoolean(),
+                    preferOriginalAudio = PREFER_ORIGINAL_AUDIO.getBoolean(),
                 )
             }
         }
@@ -544,8 +547,27 @@ object DownloadUtil {
         sorter: String,
     ) =
         preferences.run {
-            if (formatSorting && sortingFields.isNotEmpty()) addOption("-S", sortingFields)
-            else if (sorter.isNotEmpty()) addOption("-S", sorter) else {}
+            if (formatSorting && sortingFields.isNotEmpty()) {
+                val finalSorter =
+                    if (preferOriginalAudio && !sortingFields.contains("lang")) {
+                        connectWithDelimiter("lang", sortingFields, delimiter = ",")
+                    } else {
+                        sortingFields
+                    }
+                addOption("-S", finalSorter)
+            } else {
+                val finalSorter =
+                    if (preferOriginalAudio) {
+                        if (sorter.isNotEmpty()) {
+                            connectWithDelimiter("lang", sorter, delimiter = ",")
+                        } else {
+                            "lang"
+                        }
+                    } else {
+                        sorter
+                    }
+                if (finalSorter.isNotEmpty()) addOption("-S", finalSorter)
+            }
         }
 
     @CheckResult

--- a/app/src/main/java/com/junkfood/seal/util/PreferenceUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/PreferenceUtil.kt
@@ -108,6 +108,7 @@ const val MERGE_OUTPUT_MKV = "merge_to_mkv"
 const val USE_CUSTOM_AUDIO_PRESET = "custom_audio_preset"
 
 const val MERGE_MULTI_AUDIO_STREAM = "multi_audio_stream"
+const val PREFER_ORIGINAL_AUDIO = "prefer_original_audio"
 
 const val DOWNLOAD_TYPE_INITIALIZATION = "download_type_init"
 private const val DOWNLOAD_TYPE = "download_type"
@@ -218,6 +219,7 @@ private val BooleanPreferenceDefaults =
         NOTIFICATION to true,
         EMBED_METADATA to true,
         USE_CUSTOM_AUDIO_PRESET to false,
+        PREFER_ORIGINAL_AUDIO to false,
     )
 
 private val IntPreferenceDefaults =

--- a/app/src/main/java/com/junkfood/seal/util/VideoInfo.kt
+++ b/app/src/main/java/com/junkfood/seal/util/VideoInfo.kt
@@ -93,6 +93,8 @@ data class Format(
     val tbr: Double? = null,
     @SerialName("filesize") val fileSize: Double? = null,
     @SerialName("filesize_approx") val fileSizeApprox: Double? = null,
+    @SerialName("language") val language: String? = null,
+    @SerialName("language_preference") val languagePreference: Int? = null,
 ) {
     fun isAudioOnly(): Boolean = vcodec == null || vcodec == "none"
 
@@ -139,6 +141,8 @@ data class RequestedDownload(
     @SerialName("filesize") val fileSize: Double? = null,
     @SerialName("filesize_approx") val fileSizeApprox: Double? = null,
     val filename: String? = null,
+    @SerialName("language") val language: String? = null,
+    @SerialName("language_preference") val languagePreference: Int? = null,
 ) {
     fun toFormat(): Format =
         Format(
@@ -160,6 +164,8 @@ data class RequestedDownload(
             tbr = tbr,
             fileSize = fileSize,
             fileSizeApprox = fileSizeApprox,
+            language = language,
+            languagePreference = languagePreference,
         )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,8 @@
     <string name="private_directory_desc">Store downloads in a hidden directory</string>
     <string name="crop_artwork">Crop artwork</string>
     <string name="crop_artwork_desc">Crop embedded image into square</string>
+    <string name="prefer_original_audio">Prefer original audio</string>
+    <string name="prefer_original_audio_desc">Prioritize original audio track over dubbed or translated audio</string>
     <string name="download_selection_desc">Select videos to download from the playlist \"%1$s\"</string>
     <string name="select_all">Select all</string>
     <string name="selected_item_count">%1$d selected</string>


### PR DESCRIPTION
Closes #2627

### Problem
When downloading videos with multiple audio tracks (such as YouTube videos with dubbed or translated audio tracks), yt-dlp often selects a dubbed audio track instead of the original audio track because format selection defaults to bitrate/codec rather than language preference.

### Solution
- Adds a **Prefer original audio** setting in **Settings → Format → Audio** (`PREFER_ORIGINAL_AUDIO`).
- Prepends `lang` to yt-dlp's format sorter (`-S`), prioritizing audio streams with `language_preference >= 10` (original audio) over dubbed streams.
- Labels original audio tracks and language tags in the custom format selection list (`FormatItem.kt`).