### PR TITLE
fix(download): enforce cellular network restriction in DownloaderV2

### DIFF
--- a/app/src/main/java/com/junkfood/seal/download/DownloaderV2.kt
+++ b/app/src/main/java/com/junkfood/seal/download/DownloaderV2.kt
@@ -23,6 +23,7 @@ import com.junkfood.seal.util.DownloadUtil
 import com.junkfood.seal.util.FileUtil
 import com.junkfood.seal.util.NotificationUtil
 import com.junkfood.seal.util.PreferenceUtil
+import com.junkfood.seal.util.ToastUtil
 import com.junkfood.seal.util.VideoInfo
 import com.yausername.youtubedl_android.YoutubeDL
 import kotlin.collections.component1
@@ -158,6 +159,28 @@ class DownloaderV2Impl(private val appContext: Context) : DownloaderV2, KoinComp
     }
 
     override fun enqueue(task: Task) {
+        if (!PreferenceUtil.isNetworkAvailableForDownload()) {
+            taskStateMap +=
+                task to
+                    Task.State(
+                        downloadState =
+                            DownloadState.Error(
+                                throwable =
+                                    IllegalStateException(
+                                        appContext.getString(
+                                            R.string.download_disabled_with_cellular
+                                        )
+                                    ),
+                                action = Task.RestartableAction.FetchInfo,
+                            ),
+                        videoInfo = null,
+                        viewState = Task.ViewState(url = task.url, title = task.url),
+                    )
+            ToastUtil.makeToastSuspend(
+                appContext.getString(R.string.download_disabled_with_cellular)
+            )
+            return
+        }
         taskStateMap +=
             task to Task.State(Idle, null, Task.ViewState(url = task.url, title = task.url))
     }
@@ -182,6 +205,12 @@ class DownloaderV2Impl(private val appContext: Context) : DownloaderV2, KoinComp
     override fun cancel(task: Task): Boolean = task.cancelImpl()
 
     override fun restart(task: Task) {
+        if (!PreferenceUtil.isNetworkAvailableForDownload()) {
+            ToastUtil.makeToastSuspend(
+                appContext.getString(R.string.download_disabled_with_cellular)
+            )
+            return
+        }
         task.restartImpl()
     }
 
@@ -218,6 +247,29 @@ class DownloaderV2Impl(private val appContext: Context) : DownloaderV2, KoinComp
     /** Processes pending tasks, prioritizing downloads. */
     private fun doYourWork() {
         if (taskStateMap.countRunning() >= MAX_CONCURRENCY) return
+
+        if (!PreferenceUtil.isNetworkAvailableForDownload()) {
+            taskStateMap.entries
+                .filter { (_, state) ->
+                    state.downloadState == ReadyWithInfo || state.downloadState == Idle
+                }
+                .forEach { (task, state) ->
+                    val action =
+                        if (state.downloadState == ReadyWithInfo) Task.RestartableAction.Download
+                        else Task.RestartableAction.FetchInfo
+                    task.downloadState =
+                        DownloadState.Error(
+                            throwable =
+                                IllegalStateException(
+                                    appContext.getString(
+                                        R.string.download_disabled_with_cellular
+                                    )
+                                ),
+                            action = action,
+                        )
+                }
+            return
+        }
 
         taskStateMap.entries
             .sortedBy { (_, state) -> state.downloadState }


### PR DESCRIPTION
Closes #2599

### Problem
When the user disables "Download using cellular" in Settings → Network, downloads triggered via Quick Download (`QuickDownloadActivity`) or the v2 download sheet bypass the restriction because `DownloaderV2Impl` did not check `PreferenceUtil.isNetworkAvailableForDownload()`.

### Solution
- Enforce `PreferenceUtil.isNetworkAvailableForDownload()` centrally in `DownloaderV2Impl`:
  - **`enqueue(task)`**: If cellular download is disabled and network is metered, the task is enqueued in `DownloadState.Error` with the existing localized string `R.string.download_disabled_with_cellular`, and a feedback toast is shown.
  - **`restart(task)`**: Prevents retrying while still on a restricted metered network and notifies the user.
  - **`doYourWork()`**: Ensures no pending tasks proceed if the active network is restricted.
- The task remains in the download list as restartable, allowing users to retry once reconnected to Wi-Fi without losing their queued downloads.