### PR TITLE
fix(download): bound the id field in the default output template

### DIFF
--- a/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
+++ b/app/src/main/java/com/junkfood/seal/util/DownloadUtil.kt
@@ -63,7 +63,10 @@ object DownloadUtil {
 
     const val EXTENSION = ".%(ext)s"
 
-    private const val ID = "[%(id)s]"
+    // Bounded like the title above: extractors without a real id fall back to the URL basename
+    // and its query string, which overflows the 255-byte limit on a path component.
+    // https://github.com/JunkFood02/Seal/issues/1886
+    private const val ID = "[%(id).32B]"
 
     private const val CLIP_TIMESTAMP = "%(section_start)d-%(section_end)d"
 

--- a/app/src/test/java/com/junkfood/seal/util/OutputTemplateTest.kt
+++ b/app/src/test/java/com/junkfood/seal/util/OutputTemplateTest.kt
@@ -1,0 +1,104 @@
+package com.junkfood.seal.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for the yt-dlp output templates in [DownloadUtil].
+ *
+ * Every field a website controls has to carry a byte limit, otherwise the rendered name can exceed
+ * the 255-byte limit that ext4/F2FS impose on a single path component, and the download fails with
+ * `[Errno 36] File name too long`.
+ *
+ * See https://github.com/JunkFood02/Seal/issues/1886
+ */
+class OutputTemplateTest {
+
+    /**
+     * The id yt-dlp derived for the URL in issue #1886. The generic extractor falls back to the URL
+     * basename plus its query string, so an id is not necessarily short.
+     */
+    private val genericExtractorId =
+        "The_Rita_Panahi_Show_27_August.mp3?ttag=omny_clip_id:003e5d16-7f8c-440b-9e1f-b1d9007e8c01," +
+            "omny_clip_title:The Rita Panahi Show | 27 August,omny_program_name:The Rita Panahi " +
+            "Show,omny_program_slug:the-rita-panahi-show,omny_network_name:Sky News," +
+            "omny_organization_id:2fb3740d-3436-44af-8cc0-a91900716aa5,omny_playback_source:embed," +
+            "omny_playlist_id:68b93c66-ba21-4e67-a3af-ae27017458aa,omny_playlist_title:The Rita " +
+            "Panahi Show,omny_playlist_slug:podcast,omny_program_tag:Block-Alcohol," +
+            "omny_program_tag:Block-News,omny_program_tag:Block-AdultContent,omny_program_tag:" +
+            "Australian Voices,omny_program_tag:Curious Thinkers,omny_program_tag:Men 25-44," +
+            "omny_program_tag:Men 45+,omny_program_tag:News & Daily Briefing,omny_program_tag:" +
+            "Women 25-44,omny_program_tag:Women 45+,omny_program_tag:50+&t=1724753335&" +
+            "starship-rollup=v0_444444444134&starship-episode-id=757b7e3b-51ba-4031-81dc-" +
+            "af6bd1387a11&in_playlist=68b93c66-ba21-4e67-a3af-ae27017458aa&utm_source=Embed&" +
+            "embeddedUrl=https://www.skynews.com"
+
+    @Test
+    fun longGenericExtractorIdFitsWithinNameLimit() {
+        val name =
+            DownloadUtil.OUTPUT_TEMPLATE_ID.render(
+                "title" to "The_Rita_Panahi_Show_27_August",
+                "id" to genericExtractorId,
+                "ext" to "mp3",
+            )
+        assertTrue(
+            "rendered name is ${name.utf8Size()} bytes, which overflows the $NAME_LIMIT-byte limit",
+            name.utf8Size() <= NAME_LIMIT,
+        )
+    }
+
+    /** Worst case: a title that saturates its own limit next to an unbounded id. */
+    @Test
+    fun saturatedTitleAndLongIdFitWithinNameLimit() {
+        val name =
+            DownloadUtil.OUTPUT_TEMPLATE_ID.render(
+                "title" to "a".repeat(500),
+                "id" to genericExtractorId,
+                "ext" to "webm",
+            )
+        assertTrue(
+            "rendered name is ${name.utf8Size()} bytes, which overflows the $NAME_LIMIT-byte limit",
+            name.utf8Size() <= NAME_LIMIT,
+        )
+    }
+
+    /**
+     * The limit must not disturb the ids real extractors emit, which are far shorter. YouTube ids
+     * are 11 characters; the longest in common use are still well under the cap.
+     */
+    @Test
+    fun ordinaryIdsAreLeftIntact() {
+        val name =
+            DownloadUtil.OUTPUT_TEMPLATE_ID.render(
+                "title" to "Never Gonna Give You Up",
+                "id" to "dQw4w9WgXcQ",
+                "ext" to "mp4",
+            )
+        assertEquals("Never Gonna Give You Up [dQw4w9WgXcQ].mp4", name)
+    }
+
+    private companion object {
+        /** Maximum length of a single path component on ext4 and F2FS. */
+        const val NAME_LIMIT = 255
+
+        val FIELD = Regex("""%\((\w+)\)(?:\.(\d+)B)?s?""")
+
+        fun String.utf8Size(): Int = toByteArray(Charsets.UTF_8).size
+
+        /**
+         * Expands a yt-dlp output template the way yt-dlp does, honouring the `.<n>B` suffix that
+         * truncates a field to n bytes of UTF-8.
+         */
+        fun String.render(vararg fields: Pair<String, String>): String {
+            val values = fields.toMap()
+            return FIELD.replace(this) { match ->
+                val value = values.getValue(match.groupValues[1])
+                when (val limit = match.groupValues[2].toIntOrNull()) {
+                    null -> value
+                    else -> String(value.toByteArray(Charsets.UTF_8).take(limit).toByteArray())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What's wrong

The default output template is `%(title).200B [%(id)s].%(ext)s` (`OUTPUT_TEMPLATE_ID`, set as the default in `PreferenceUtil.kt:208`). The title is bounded to 200 bytes; the id is not bounded at all.

An id is not always short. When no extractor claims a URL, yt-dlp's generic extractor derives the id from the URL basename **plus its query string**. For the URL in #1886 that id is 986 bytes, so the rendered name comes to 1023 bytes — against the 255-byte limit ext4 and F2FS place on a single path component. The download dies before it starts:

```
ERROR: unable to open for writing: [Errno 36] File name too long:
'/storage/emulated/0/Download/Seal/The_Rita_Panahi_Show_27_August [The_Rita_Panahi_Show_27_August.mp3？ttag=omny_clip_id：003e5d16-…&embeddedUrl=https：⧸⧸www.skynews.com].mp3'
```

`--restrict-filenames` does not help, as the reporter notes: it changes which characters are used, not how many.

### What changed

One constant — the id gets the same kind of byte bound the title already has:

```kotlin
-    private const val ID = "[%(id)s]"
+    private const val ID = "[%(id).32B]"
```

32 bytes is what's left after budgeting for the rest of the worst case: 200 (title) + 2 (` [`) + 32 + 1 (`]`) + 9 (`.f<format_id>`, which yt-dlp gives the intermediate per-format files) + 5 (`.webm`) = 249 bytes, six under the limit.

### The trade-off

**Ids longer than 32 bytes are now truncated in the filename.** For every mainstream extractor this changes nothing — YouTube ids are 11 characters, Twitter/X 19, Bilibili 12, TikTok 19, Vimeo 9. The case it does touch is a bare UUID id (36 characters), which loses its last four; the remaining 32 still make a collision unrealistic, but the name is cosmetically shorter. I took that over a download that cannot start.

I considered yt-dlp's `--trim-filenames` instead, which would bound the whole name in one option rather than field by field. I didn't use it because it counts characters rather than bytes, so it doesn't actually guarantee the 255-**byte** limit for non-ASCII titles, and it would change behaviour for every download rather than only the broken ones. Happy to switch if you'd rather have that, or to move the number.

### Tests

`app/src/test/java/com/junkfood/seal/util/OutputTemplateTest.kt` renders the templates the way yt-dlp does (honouring the `.<n>B` byte-truncation suffix) and asserts the result fits a path component. It uses the reporter's real 986-byte id, not a stand-in.

Verified failing before the change and passing after:

```
# before
OutputTemplateTest > saturatedTitleAndLongIdFitWithinNameLimit FAILED
    rendered name is 1194 bytes, which overflows the 255-byte limit
OutputTemplateTest > longGenericExtractorIdFitsWithinNameLimit FAILED
    rendered name is 1023 bytes, which overflows the 255-byte limit
3 tests completed, 2 failed

# after
BUILD SUCCESSFUL — ExampleUnitTest 2 tests, 0 failures
                   OutputTemplateTest 3 tests, 0 failures
```

The third test, `ordinaryIdsAreLeftIntact`, passes both before and after by design — it's there to catch over-correction, i.e. a future bound tight enough to start mangling ordinary ids.

`./gradlew buildGenericRelease` (what CI runs) and `./gradlew :app:ktfmtCheckTest` both pass. I deliberately did not run `ktfmtFormat` across the project: six files including this one are already unformatted on `main`, and reformatting them would bury a two-line change.

### Scope

Two adjacent things I found and left alone, rather than widen this PR — say the word if you want either:

- `PLAYLIST_TITLE_SUBDIRECTORY_PREFIX = "%(playlist)s/"` is unbounded in the same way. It's a directory component, subject to the same 255-byte limit, but nobody has reported it.
- #2474 reports the same `Errno 36` for X/Twitter posts. I could not confirm it has this cause — X ids are ~19 digits and titles are already bounded — so I've left that issue out rather than claim a fix I haven't verified.
